### PR TITLE
specs: add a specifications section to the site

### DIFF
--- a/docs/assets/secure-launch-specification.pdf
+++ b/docs/assets/secure-launch-specification.pdf
@@ -1,0 +1,5746 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 97 0 R /F4 99 0 R /F5 101 0 R /F6 104 0 R 
+  /F7 105 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 165 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 591.0236 0 ] /Rect [ 62.69291 723.0236 134.9229 735.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+6 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 591.0236 0 ] /Rect [ 527.0227 723.7736 532.5827 735.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+7 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 414.0236 0 ] /Rect [ 62.69291 705.0236 136.6029 717.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+8 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 414.0236 0 ] /Rect [ 527.0227 705.7736 532.5827 717.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+9 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 381.0236 0 ] /Rect [ 82.69291 687.0236 214.4329 699.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+10 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 381.0236 0 ] /Rect [ 527.0227 687.7736 532.5827 699.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+11 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 309.0236 0 ] /Rect [ 82.69291 669.0236 149.3829 681.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+12 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 309.0236 0 ] /Rect [ 527.0227 669.7736 532.5827 681.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+13 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 207.0236 0 ] /Rect [ 62.69291 651.0236 209.9629 663.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+14 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 207.0236 0 ] /Rect [ 527.0227 651.7736 532.5827 663.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+15 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 174.0236 0 ] /Rect [ 82.69291 633.0236 253.3429 645.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+16 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 98 0 R /XYZ 62.69291 174.0236 0 ] /Rect [ 527.0227 633.7736 532.5827 645.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+17 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 652.0236 0 ] /Rect [ 102.6929 615.0236 211.6429 627.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+18 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 652.0236 0 ] /Rect [ 527.0227 615.7736 532.5827 627.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+19 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 544.0236 0 ] /Rect [ 82.69291 597.0236 245.5429 609.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+20 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 544.0236 0 ] /Rect [ 527.0227 597.7736 532.5827 609.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+21 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 460.0236 0 ] /Rect [ 82.69291 579.0236 245.5529 591.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+22 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 460.0236 0 ] /Rect [ 527.0227 579.7736 532.5827 591.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+23 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 364.0236 0 ] /Rect [ 82.69291 561.0236 198.3129 573.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+24 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 100 0 R /XYZ 62.69291 364.0236 0 ] /Rect [ 527.0227 561.7736 532.5827 573.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+25 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 82.69291 543.0236 149.9629 555.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+26 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 527.0227 543.7736 532.5827 555.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+27 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 197.8236 0 ] /Rect [ 62.69291 525.0236 198.3029 537.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+28 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 197.8236 0 ] /Rect [ 527.0227 525.7736 532.5827 537.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+29 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 146.8236 0 ] /Rect [ 82.69291 507.0236 221.6429 519.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+30 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 146.8236 0 ] /Rect [ 527.0227 507.7736 532.5827 519.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+31 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 98.82362 0 ] /Rect [ 102.6929 489.0236 235.5229 501.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+32 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 102 0 R /XYZ 62.69291 98.82362 0 ] /Rect [ 527.0227 489.7736 532.5827 501.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+33 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 103 0 R /XYZ 62.69291 621.0236 0 ] /Rect [ 82.69291 471.0236 189.9629 483.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+34 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 103 0 R /XYZ 62.69291 621.0236 0 ] /Rect [ 527.0227 471.7736 532.5827 483.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+35 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 103 0 R /XYZ 62.69291 495.0236 0 ] /Rect [ 82.69291 453.0236 207.1829 465.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+36 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 103 0 R /XYZ 62.69291 495.0236 0 ] /Rect [ 527.0227 453.7736 532.5827 465.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+37 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 82.69291 435.0236 173.8429 447.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+38 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 527.0227 435.7736 532.5827 447.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+39 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 693.0236 0 ] /Rect [ 102.6929 417.0236 219.9729 429.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+40 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 693.0236 0 ] /Rect [ 527.0227 417.7736 532.5827 429.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+41 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 612.0236 0 ] /Rect [ 122.6929 399.0236 227.7429 411.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+42 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 612.0236 0 ] /Rect [ 527.0227 399.7736 532.5827 411.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+43 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 492.0236 0 ] /Rect [ 102.6929 381.0236 188.8429 393.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+44 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 492.0236 0 ] /Rect [ 527.0227 381.7736 532.5827 393.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+45 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 447.0236 0 ] /Rect [ 122.6929 363.0236 222.7429 375.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+46 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 447.0236 0 ] /Rect [ 527.0227 363.7736 532.5827 375.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+47 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 194.8236 0 ] /Rect [ 122.6929 345.0236 248.8629 357.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+48 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 106 0 R /XYZ 62.69291 194.8236 0 ] /Rect [ 527.0227 345.7736 532.5827 357.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+49 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 107 0 R /XYZ 62.69291 691.8236 0 ] /Rect [ 142.6929 327.0236 291.6529 339.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+50 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 107 0 R /XYZ 62.69291 691.8236 0 ] /Rect [ 527.0227 327.7736 532.5827 339.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+51 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 107 0 R /XYZ 62.69291 508.6236 0 ] /Rect [ 122.6929 309.0236 298.3329 321.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+52 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 107 0 R /XYZ 62.69291 508.6236 0 ] /Rect [ 527.0227 309.7736 532.5827 321.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+53 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 107 0 R /XYZ 62.69291 214.4236 0 ] /Rect [ 142.6929 291.0236 281.6729 303.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+54 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 107 0 R /XYZ 62.69291 214.4236 0 ] /Rect [ 527.0227 291.7736 532.5827 303.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+55 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 108 0 R /XYZ 62.69291 629.8236 0 ] /Rect [ 122.6929 273.0236 262.1929 285.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+56 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 108 0 R /XYZ 62.69291 629.8236 0 ] /Rect [ 527.0227 273.7736 532.5827 285.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+57 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 108 0 R /XYZ 62.69291 276.6236 0 ] /Rect [ 122.6929 255.0236 287.1829 267.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+58 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 108 0 R /XYZ 62.69291 276.6236 0 ] /Rect [ 527.0227 255.7736 532.5827 267.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+59 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 109 0 R /XYZ 62.69291 629.8236 0 ] /Rect [ 142.6929 237.0236 274.4029 249.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+60 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 109 0 R /XYZ 62.69291 629.8236 0 ] /Rect [ 521.4627 237.7736 532.5827 249.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+61 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 109 0 R /XYZ 62.69291 338.6236 0 ] /Rect [ 162.6929 219.0236 363.8729 231.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+62 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 109 0 R /XYZ 62.69291 338.6236 0 ] /Rect [ 521.4627 219.7736 532.5827 231.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+63 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 109 0 R /XYZ 62.69291 167.4236 0 ] /Rect [ 162.6929 201.0236 333.3029 213.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+64 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 109 0 R /XYZ 62.69291 167.4236 0 ] /Rect [ 521.4627 201.7736 532.5827 213.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+65 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 102.6929 183.0236 218.8529 195.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+66 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 521.4627 183.7736 532.5827 195.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+67 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 720.0236 0 ] /Rect [ 122.6929 165.0236 221.6429 177.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+68 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 720.0236 0 ] /Rect [ 521.4627 165.7736 532.5827 177.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+69 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 482.8236 0 ] /Rect [ 142.6929 147.0236 276.0929 159.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+70 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 482.8236 0 ] /Rect [ 521.4627 147.7736 532.5827 159.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+71 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 158.6236 0 ] /Rect [ 102.6929 129.0236 270.5429 141.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+72 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 158.6236 0 ] /Rect [ 521.4627 129.7736 532.5827 141.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+73 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 131.6236 0 ] /Rect [ 122.6929 111.0236 238.3029 123.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+74 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 110 0 R /XYZ 62.69291 131.6236 0 ] /Rect [ 521.4627 111.7736 532.5827 123.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+75 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 703.8236 0 ] /Rect [ 102.6929 93.02362 251.0629 105.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+76 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 703.8236 0 ] /Rect [ 521.4627 93.77362 532.5827 105.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+77 0 obj
+<<
+/Annots [ 5 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 13 0 R 14 0 R 
+  15 0 R 16 0 R 17 0 R 18 0 R 19 0 R 20 0 R 21 0 R 22 0 R 23 0 R 24 0 R 
+  25 0 R 26 0 R 27 0 R 28 0 R 29 0 R 30 0 R 31 0 R 32 0 R 33 0 R 34 0 R 
+  35 0 R 36 0 R 37 0 R 38 0 R 39 0 R 40 0 R 41 0 R 42 0 R 43 0 R 44 0 R 
+  45 0 R 46 0 R 47 0 R 48 0 R 49 0 R 50 0 R 51 0 R 52 0 R 53 0 R 54 0 R 
+  55 0 R 56 0 R 57 0 R 58 0 R 59 0 R 60 0 R 61 0 R 62 0 R 63 0 R 64 0 R 
+  65 0 R 66 0 R 67 0 R 68 0 R 69 0 R 70 0 R 71 0 R 72 0 R 73 0 R 74 0 R 
+  75 0 R 76 0 R ] /Contents 166 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+78 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 676.8236 0 ] /Rect [ 122.6929 750.0236 203.2929 762.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+79 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 676.8236 0 ] /Rect [ 521.4627 750.7736 532.5827 762.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+80 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 577.6236 0 ] /Rect [ 102.6929 732.0236 219.9629 744.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+81 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 577.6236 0 ] /Rect [ 521.4627 732.7736 532.5827 744.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+82 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 520.6236 0 ] /Rect [ 122.6929 714.0236 203.8529 726.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+83 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 520.6236 0 ] /Rect [ 521.4627 714.7736 532.5827 726.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+84 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 421.4236 0 ] /Rect [ 122.6929 696.0236 216.0729 708.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+85 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 421.4236 0 ] /Rect [ 521.4627 696.7736 532.5827 708.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+86 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 196.2236 0 ] /Rect [ 142.6929 678.0236 270.5329 690.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+87 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 111 0 R /XYZ 62.69291 196.2236 0 ] /Rect [ 521.4627 678.7736 532.5827 690.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+88 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 112 0 R /XYZ 62.69291 632.8236 0 ] /Rect [ 62.69291 660.0236 269.9529 672.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+89 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 112 0 R /XYZ 62.69291 632.8236 0 ] /Rect [ 521.4627 660.7736 532.5827 672.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+90 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 112 0 R /XYZ 62.69291 533.8236 0 ] /Rect [ 82.69291 642.0236 206.6429 654.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+91 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 112 0 R /XYZ 62.69291 533.8236 0 ] /Rect [ 521.4627 642.7736 532.5827 654.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+92 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 112 0 R /XYZ 62.69291 371.8236 0 ] /Rect [ 82.69291 624.0236 197.7429 636.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+93 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 112 0 R /XYZ 62.69291 371.8236 0 ] /Rect [ 521.4627 624.7736 532.5827 636.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+94 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 62.69291 606.0236 224.3929 618.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+95 0 obj
+<<
+/Border [ 0 0 0 ] /Contents () /Dest [ 115 0 R /XYZ 62.69291 765.0236 0 ] /Rect [ 521.4627 606.7736 532.5827 618.7736 ] /Subtype /Link /Type /Annot
+>>
+endobj
+96 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (http://tools.ietf.org/html/rfc2119.html)
+>> /Border [ 0 0 0 ] /Rect [ 119.3829 321.0236 164.9529 333.0236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+97 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+98 0 obj
+<<
+/Annots [ 78 0 R 79 0 R 80 0 R 81 0 R 82 0 R 83 0 R 84 0 R 85 0 R 86 0 R 87 0 R 
+  88 0 R 89 0 R 90 0 R 91 0 R 92 0 R 93 0 R 94 0 R 95 0 R 96 0 R ] /Contents 167 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+99 0 obj
+<<
+/BaseFont /Helvetica-BoldOblique /Encoding /WinAnsiEncoding /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+100 0 obj
+<<
+/Contents 168 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+101 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F5 /Subtype /Type1 /Type /Font
+>>
+endobj
+102 0 obj
+<<
+/Contents 169 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+103 0 obj
+<<
+/Contents 170 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+104 0 obj
+<<
+/BaseFont /Courier-Bold /Encoding /WinAnsiEncoding /Name /F6 /Subtype /Type1 /Type /Font
+>>
+endobj
+105 0 obj
+<<
+/BaseFont /Courier-Oblique /Encoding /WinAnsiEncoding /Name /F7 /Subtype /Type1 /Type /Font
+>>
+endobj
+106 0 obj
+<<
+/Contents 171 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+107 0 obj
+<<
+/Contents 172 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+108 0 obj
+<<
+/Contents 173 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+109 0 obj
+<<
+/Contents 174 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+110 0 obj
+<<
+/Contents 175 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+111 0 obj
+<<
+/Contents 176 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+112 0 obj
+<<
+/Contents 177 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+113 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.intel.com/content/www/us/en/content-details/315168/intel-trusted-execution-technology-intel-txt-software-development-guide.html?wapkw=txt)
+>> /Border [ 0 0 0 ] /Rect [ 76.59291 519.8236 529.0029 531.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+114 0 obj
+<<
+/A <<
+/S /URI /Type /Action /URI (https://www.intel.com/content/www/us/en/content-details/315168/intel-trusted-execution-technology-intel-txt-software-development-guide.html?wapkw=txt)
+>> /Border [ 0 0 0 ] /Rect [ 62.69291 507.8236 288.0429 519.8236 ] /Subtype /Link /Type /Annot
+>>
+endobj
+115 0 obj
+<<
+/Annots [ 113 0 R 114 0 R ] /Contents 178 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 164 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 
+  /Trans <<
+
+>> /Type /Page
+>>
+endobj
+116 0 obj
+<<
+/Outlines 118 0 R /PageLabels 179 0 R /PageMode /UseNone /Pages 164 0 R /Type /Catalog
+>>
+endobj
+117 0 obj
+<<
+/Author () /CreationDate (D:20230502125349+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20230502125349+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (\(unspecified\)) /Title (Secure Launch Specification) /Trapped /False
+>>
+endobj
+118 0 obj
+<<
+/Count 64 /First 119 0 R /Last 163 0 R /Type /Outlines
+>>
+endobj
+119 0 obj
+<<
+/Dest [ 98 0 R /XYZ 62.69291 591.0236 0 ] /Next 120 0 R /Parent 118 0 R /Title (\376\377\0001\000\240\000\240\000\240\000I\000n\000t\000r\000o\000d\000u\000c\000t\000i\000o\000n)
+>>
+endobj
+120 0 obj
+<<
+/Count 2 /Dest [ 98 0 R /XYZ 62.69291 414.0236 0 ] /First 121 0 R /Last 122 0 R /Next 123 0 R /Parent 118 0 R 
+  /Prev 119 0 R /Title (\376\377\0002\000\240\000\240\000\240\000T\000e\000r\000m\000i\000n\000o\000l\000o\000g\000y)
+>>
+endobj
+121 0 obj
+<<
+/Dest [ 98 0 R /XYZ 62.69291 381.0236 0 ] /Next 122 0 R /Parent 120 0 R /Title (\376\377\0002\000.\0001\000\240\000\240\000\240\000R\000e\000q\000u\000i\000r\000e\000m\000e\000n\000t\000s\000 \000L\000a\000n\000g\000u\000a\000g\000e)
+>>
+endobj
+122 0 obj
+<<
+/Dest [ 98 0 R /XYZ 62.69291 309.0236 0 ] /Parent 120 0 R /Prev 121 0 R /Title (\376\377\0002\000.\0002\000\240\000\240\000\240\000A\000c\000r\000o\000n\000y\000m\000s)
+>>
+endobj
+123 0 obj
+<<
+/Count 6 /Dest [ 98 0 R /XYZ 62.69291 207.0236 0 ] /First 124 0 R /Last 129 0 R /Next 130 0 R /Parent 118 0 R 
+  /Prev 120 0 R /Title (\376\377\0003\000\240\000\240\000\240\000S\000e\000c\000u\000r\000e\000 \000L\000a\000u\000n\000c\000h\000 \000A\000r\000c\000h\000i\000t\000e\000c\000t\000u\000r\000e)
+>>
+endobj
+124 0 obj
+<<
+/Count 1 /Dest [ 98 0 R /XYZ 62.69291 174.0236 0 ] /First 125 0 R /Last 125 0 R /Next 126 0 R /Parent 123 0 R 
+  /Title (\376\377\0003\000.\0001\000\240\000\240\000\240\000S\000e\000c\000u\000r\000e\000 \000L\000a\000u\000n\000c\000h\000 \000a\000w\000a\000r\000e\000 \000B\000o\000o\000t\000l\000o\000a\000d\000e\000r)
+>>
+endobj
+125 0 obj
+<<
+/Dest [ 100 0 R /XYZ 62.69291 652.0236 0 ] /Parent 124 0 R /Title (\376\377\0003\000.\0001\000.\0001\000\240\000\240\000\240\000B\000o\000o\000t\000l\000o\000a\000d\000e\000r\000 \000T\000y\000p\000e\000s)
+>>
+endobj
+126 0 obj
+<<
+/Dest [ 100 0 R /XYZ 62.69291 544.0236 0 ] /Next 127 0 R /Parent 123 0 R /Prev 124 0 R /Title (\376\377\0003\000.\0002\000\240\000\240\000\240\000D\000y\000n\000a\000m\000i\000c\000 \000L\000a\000u\000n\000c\000h\000 \000E\000v\000e\000n\000t\000 \000H\000a\000n\000d\000l\000e\000r)
+>>
+endobj
+127 0 obj
+<<
+/Dest [ 100 0 R /XYZ 62.69291 460.0236 0 ] /Next 128 0 R /Parent 123 0 R /Prev 126 0 R /Title (\376\377\0003\000.\0003\000\240\000\240\000\240\000S\000e\000c\000u\000r\000e\000 \000L\000a\000u\000n\000c\000h\000 \000R\000e\000s\000o\000u\000r\000c\000e\000 \000T\000a\000b\000l\000e)
+>>
+endobj
+128 0 obj
+<<
+/Dest [ 100 0 R /XYZ 62.69291 364.0236 0 ] /Next 129 0 R /Parent 123 0 R /Prev 127 0 R /Title (\376\377\0003\000.\0004\000\240\000\240\000\240\000S\000e\000c\000u\000r\000e\000 \000L\000a\000u\000n\000c\000h\000 \000E\000n\000t\000r\000y)
+>>
+endobj
+129 0 obj
+<<
+/Dest [ 102 0 R /XYZ 62.69291 765.0236 0 ] /Parent 123 0 R /Prev 128 0 R /Title (\376\377\0003\000.\0005\000\240\000\240\000\240\000S\000e\000q\000u\000e\000n\000c\000e)
+>>
+endobj
+130 0 obj
+<<
+/Count 29 /Dest [ 102 0 R /XYZ 62.69291 197.8236 0 ] /First 131 0 R /Last 135 0 R /Next 160 0 R /Parent 118 0 R 
+  /Prev 123 0 R /Title (\376\377\0004\000\240\000\240\000\240\000S\000e\000c\000u\000r\000e\000 \000L\000a\000u\000n\000c\000h\000 \000I\000n\000t\000e\000r\000f\000a\000c\000e\000s)
+>>
+endobj
+131 0 obj
+<<
+/Count 1 /Dest [ 102 0 R /XYZ 62.69291 146.8236 0 ] /First 132 0 R /Last 132 0 R /Next 133 0 R /Parent 130 0 R 
+  /Title (\376\377\0004\000.\0001\000\240\000\240\000\240\000D\000L\000E\000 \000H\000a\000n\000d\000l\000e\000r\000 \000S\000p\000e\000c\000i\000f\000i\000c\000a\000t\000i\000o\000n)
+>>
+endobj
+132 0 obj
+<<
+/Dest [ 102 0 R /XYZ 62.69291 98.82362 0 ] /Parent 131 0 R /Title (\376\377\0004\000.\0001\000.\0001\000\240\000\240\000\240\000P\000l\000a\000t\000f\000o\000r\000m\000 \000R\000e\000q\000u\000i\000r\000e\000m\000e\000n\000t\000s)
+>>
+endobj
+133 0 obj
+<<
+/Dest [ 103 0 R /XYZ 62.69291 621.0236 0 ] /Next 134 0 R /Parent 130 0 R /Prev 131 0 R /Title (\376\377\0004\000.\0002\000\240\000\240\000\240\000S\000L\000R\000T\000 \000S\000p\000e\000c\000i\000f\000i\000c\000a\000t\000i\000o\000n)
+>>
+endobj
+134 0 obj
+<<
+/Dest [ 103 0 R /XYZ 62.69291 495.0236 0 ] /Next 135 0 R /Parent 130 0 R /Prev 133 0 R /Title (\376\377\0004\000.\0003\000\240\000\240\000\240\000P\000l\000a\000t\000f\000o\000r\000m\000 \000R\000e\000q\000u\000i\000r\000e\000m\000e\000n\000t\000s)
+>>
+endobj
+135 0 obj
+<<
+/Count 24 /Dest [ 106 0 R /XYZ 62.69291 765.0236 0 ] /First 136 0 R /Last 156 0 R /Parent 130 0 R /Prev 134 0 R 
+  /Title (\376\377\0004\000.\0004\000\240\000\240\000\240\000S\000L\000R\000T\000 \000S\000t\000r\000u\000c\000t\000u\000r\000e)
+>>
+endobj
+136 0 obj
+<<
+/Count 1 /Dest [ 106 0 R /XYZ 62.69291 693.0236 0 ] /First 137 0 R /Last 137 0 R /Next 138 0 R /Parent 135 0 R 
+  /Title (\376\377\0004\000.\0004\000.\0001\000\240\000\240\000\240\000V\000e\000r\000s\000i\000o\000n\000i\000n\000g\000 \000S\000c\000h\000e\000m\000e)
+>>
+endobj
+137 0 obj
+<<
+/Dest [ 106 0 R /XYZ 62.69291 612.0236 0 ] /Parent 136 0 R /Title (\376\377\0004\000.\0004\000.\0001\000.\0001\000\240\000\240\000\240\000R\000e\000v\000i\000s\000i\000o\000n\000 \000T\000a\000b\000l\000e)
+>>
+endobj
+138 0 obj
+<<
+/Count 10 /Dest [ 106 0 R /XYZ 62.69291 492.0236 0 ] /First 139 0 R /Last 145 0 R /Next 149 0 R /Parent 135 0 R 
+  /Prev 136 0 R /Title (\376\377\0004\000.\0004\000.\0002\000\240\000\240\000\240\000C\000o\000r\000e\000 \000E\000n\000t\000r\000i\000e\000s)
+>>
+endobj
+139 0 obj
+<<
+/Dest [ 106 0 R /XYZ 62.69291 447.0236 0 ] /Next 140 0 R /Parent 138 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0001\000\240\000\240\000\240\000S\000L\000R\000T\000 \000H\000e\000a\000d\000e\000r)
+>>
+endobj
+140 0 obj
+<<
+/Count 1 /Dest [ 106 0 R /XYZ 62.69291 194.8236 0 ] /First 141 0 R /Last 141 0 R /Next 142 0 R /Parent 138 0 R 
+  /Prev 139 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0002\000\240\000\240\000\240\000S\000L\000R\000T\000 \000E\000n\000t\000r\000y\000 \000H\000e\000a\000d\000e\000r)
+>>
+endobj
+141 0 obj
+<<
+/Dest [ 107 0 R /XYZ 62.69291 691.8236 0 ] /Parent 140 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0002\000.\0001\000\240\000\240\000\240\000S\000L\000R\000T\000 \000E\000n\000t\000r\000y\000 \000T\000a\000g\000 \000T\000y\000p\000e\000s)
+>>
+endobj
+142 0 obj
+<<
+/Count 1 /Dest [ 107 0 R /XYZ 62.69291 508.6236 0 ] /First 143 0 R /Last 143 0 R /Next 144 0 R /Parent 138 0 R 
+  /Prev 140 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0003\000\240\000\240\000\240\000D\000y\000n\000a\000m\000i\000c\000 \000L\000a\000u\000n\000c\000h\000 \000C\000o\000n\000f\000i\000g\000u\000r\000a\000t\000i\000o\000n)
+>>
+endobj
+143 0 obj
+<<
+/Dest [ 107 0 R /XYZ 62.69291 214.4236 0 ] /Parent 142 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0003\000.\0001\000\240\000\240\000\240\000B\000o\000o\000t\000 \000L\000o\000a\000d\000e\000r\000 \000C\000o\000n\000t\000e\000x\000t)
+>>
+endobj
+144 0 obj
+<<
+/Dest [ 108 0 R /XYZ 62.69291 629.8236 0 ] /Next 145 0 R /Parent 138 0 R /Prev 142 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0004\000\240\000\240\000\240\000D\000R\000T\000M\000 \000T\000P\000M\000 \000E\000v\000e\000n\000t\000 \000L\000o\000g)
+>>
+endobj
+145 0 obj
+<<
+/Count 3 /Dest [ 108 0 R /XYZ 62.69291 276.6236 0 ] /First 146 0 R /Last 146 0 R /Parent 138 0 R /Prev 144 0 R 
+  /Title (\376\377\0004\000.\0004\000.\0002\000.\0005\000\240\000\240\000\240\000D\000-\000R\000T\000M\000 \000M\000e\000a\000s\000u\000r\000e\000m\000e\000n\000t\000 \000P\000o\000l\000i\000c\000y)
+>>
+endobj
+146 0 obj
+<<
+/Count 2 /Dest [ 109 0 R /XYZ 62.69291 629.8236 0 ] /First 147 0 R /Last 148 0 R /Parent 145 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0005\000.\0001\000\240\000\240\000\240\000D\000R\000T\000M\000 \000P\000o\000l\000i\000c\000y\000 \000E\000n\000t\000r\000y)
+>>
+endobj
+147 0 obj
+<<
+/Dest [ 109 0 R /XYZ 62.69291 338.6236 0 ] /Next 148 0 R /Parent 146 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0005\000.\0001\000.\0001\000\240\000\240\000\240\000D\000-\000R\000T\000M\000 \000P\000o\000l\000i\000c\000y\000 \000E\000n\000t\000r\000y\000 \000E\000n\000t\000i\000t\000y\000 \000T\000y\000p\000e\000s)
+>>
+endobj
+148 0 obj
+<<
+/Dest [ 109 0 R /XYZ 62.69291 167.4236 0 ] /Parent 146 0 R /Prev 147 0 R /Title (\376\377\0004\000.\0004\000.\0002\000.\0005\000.\0001\000.\0002\000\240\000\240\000\240\000D\000-\000R\000T\000M\000 \000P\000o\000l\000i\000c\000y\000 \000E\000n\000t\000r\000y\000 \000F\000l\000a\000g\000s)
+>>
+endobj
+149 0 obj
+<<
+/Count 2 /Dest [ 110 0 R /XYZ 62.69291 765.0236 0 ] /First 150 0 R /Last 150 0 R /Next 152 0 R /Parent 135 0 R 
+  /Prev 138 0 R /Title (\376\377\0004\000.\0004\000.\0003\000\240\000\240\000\240\000I\000n\000t\000e\000l\000 \000T\000X\000T\000 \000P\000l\000a\000t\000f\000o\000r\000m\000s)
+>>
+endobj
+150 0 obj
+<<
+/Count 1 /Dest [ 110 0 R /XYZ 62.69291 720.0236 0 ] /First 151 0 R /Last 151 0 R /Parent 149 0 R /Title (\376\377\0004\000.\0004\000.\0003\000.\0001\000\240\000\240\000\240\000I\000n\000t\000e\000l\000 \000T\000X\000T\000 \000I\000n\000f\000o)
+>>
+endobj
+151 0 obj
+<<
+/Dest [ 110 0 R /XYZ 62.69291 482.8236 0 ] /Parent 150 0 R /Title (\376\377\0004\000.\0004\000.\0003\000.\0001\000.\0001\000\240\000\240\000\240\000S\000a\000v\000e\000d\000 \000M\000T\000R\000R\000 \000S\000t\000a\000t\000e)
+>>
+endobj
+152 0 obj
+<<
+/Count 1 /Dest [ 110 0 R /XYZ 62.69291 158.6236 0 ] /First 153 0 R /Last 153 0 R /Next 154 0 R /Parent 135 0 R 
+  /Prev 149 0 R /Title (\376\377\0004\000.\0004\000.\0004\000\240\000\240\000\240\000A\000M\000D\000 \000S\000e\000c\000u\000r\000e\000 \000L\000a\000u\000n\000c\000h\000 \000P\000l\000a\000t\000f\000o\000r\000m\000s)
+>>
+endobj
+153 0 obj
+<<
+/Dest [ 110 0 R /XYZ 62.69291 131.6236 0 ] /Parent 152 0 R /Title (\376\377\0004\000.\0004\000.\0004\000.\0001\000\240\000\240\000\240\000A\000M\000D\000 \000S\000K\000I\000N\000I\000T\000 \000I\000n\000f\000o)
+>>
+endobj
+154 0 obj
+<<
+/Count 1 /Dest [ 111 0 R /XYZ 62.69291 703.8236 0 ] /First 155 0 R /Last 155 0 R /Next 156 0 R /Parent 135 0 R 
+  /Prev 152 0 R /Title (\376\377\0004\000.\0004\000.\0005\000\240\000\240\000\240\000A\000R\000M\000 \000D\000R\000T\000M\000 \000E\000n\000v\000i\000r\000o\000n\000m\000e\000n\000t\000s)
+>>
+endobj
+155 0 obj
+<<
+/Dest [ 111 0 R /XYZ 62.69291 676.8236 0 ] /Parent 154 0 R /Title (\376\377\0004\000.\0004\000.\0005\000.\0001\000\240\000\240\000\240\000A\000R\000M\000 \000I\000n\000f\000o)
+>>
+endobj
+156 0 obj
+<<
+/Count 3 /Dest [ 111 0 R /XYZ 62.69291 577.6236 0 ] /First 157 0 R /Last 158 0 R /Parent 135 0 R /Prev 154 0 R 
+  /Title (\376\377\0004\000.\0004\000.\0006\000\240\000\240\000\240\000U\000E\000F\000I\000 \000E\000n\000v\000i\000r\000o\000n\000m\000e\000n\000t\000s)
+>>
+endobj
+157 0 obj
+<<
+/Dest [ 111 0 R /XYZ 62.69291 520.6236 0 ] /Next 158 0 R /Parent 156 0 R /Title (\376\377\0004\000.\0004\000.\0006\000.\0001\000\240\000\240\000\240\000U\000E\000F\000I\000 \000I\000n\000f\000o)
+>>
+endobj
+158 0 obj
+<<
+/Count 1 /Dest [ 111 0 R /XYZ 62.69291 421.4236 0 ] /First 159 0 R /Last 159 0 R /Parent 156 0 R /Prev 157 0 R 
+  /Title (\376\377\0004\000.\0004\000.\0006\000.\0002\000\240\000\240\000\240\000U\000E\000F\000I\000 \000C\000o\000n\000f\000i\000g)
+>>
+endobj
+159 0 obj
+<<
+/Dest [ 111 0 R /XYZ 62.69291 196.2236 0 ] /Parent 158 0 R /Title (\376\377\0004\000.\0004\000.\0006\000.\0002\000.\0001\000\240\000\240\000\240\000U\000E\000F\000I\000 \000C\000o\000n\000f\000i\000g\000 \000E\000n\000t\000r\000y)
+>>
+endobj
+160 0 obj
+<<
+/Count 2 /Dest [ 112 0 R /XYZ 62.69291 632.8236 0 ] /First 161 0 R /Last 162 0 R /Next 163 0 R /Parent 118 0 R 
+  /Prev 130 0 R /Title (\376\377\0005\000\240\000\240\000\240\000A\000p\000p\000e\000n\000d\000i\000x\000 \000A\000:\000 \000M\000e\000a\000s\000u\000r\000i\000n\000g\000 \000t\000h\000e\000 \000D\000R\000T\000M\000 \000P\000o\000l\000i\000c\000y)
+>>
+endobj
+161 0 obj
+<<
+/Dest [ 112 0 R /XYZ 62.69291 533.8236 0 ] /Next 162 0 R /Parent 160 0 R /Title (\376\377\0005\000.\0001\000\240\000\240\000\240\000T\000P\000M\000 \000E\000x\000t\000e\000n\000d\000 \000O\000p\000e\000r\000a\000t\000i\000o\000n)
+>>
+endobj
+162 0 obj
+<<
+/Dest [ 112 0 R /XYZ 62.69291 371.8236 0 ] /Parent 160 0 R /Prev 161 0 R /Title (\376\377\0005\000.\0002\000\240\000\240\000\240\000M\000e\000a\000s\000u\000r\000i\000n\000g\000 \000t\000h\000e\000 \000P\000o\000l\000i\000c\000y)
+>>
+endobj
+163 0 obj
+<<
+/Dest [ 115 0 R /XYZ 62.69291 765.0236 0 ] /Parent 118 0 R /Prev 160 0 R /Title (\376\377\0006\000\240\000\240\000\240\000A\000p\000p\000e\000n\000d\000i\000x\000 \000B\000:\000 \000I\000n\000t\000e\000l\000 \000T\000X\000T\000 \000O\000S\0002\000M\000L\000E)
+>>
+endobj
+164 0 obj
+<<
+/Count 14 /Kids [ 4 0 R 77 0 R 98 0 R 100 0 R 102 0 R 103 0 R 106 0 R 107 0 R 108 0 R 109 0 R 
+  110 0 R 111 0 R 112 0 R 115 0 R ] /Type /Pages
+>>
+endobj
+165 0 obj
+<<
+/Length 759
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 741.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 4 Tm /F2 20 Tf 24 TL 98.23488 0 Td (Secure Launch Specification) Tj T* -98.23488 0 Td ET
+Q
+Q
+q
+1 0 0 1 62.69291 719.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 202.4299 0 Td 12 TL /F2 10 Tf 0 0 0 rg (Version:) Tj /F1 10 Tf ( 0.5.0) Tj T* -202.4299 0 Td ET
+Q
+Q
+q
+1 0 0 1 62.69291 701.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 214.1149 0 Td (Authors:) Tj T* -214.1149 0 Td ET
+Q
+Q
+q
+1 0 0 1 62.69291 683.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 41.27988 0 Td 12 TL /F2 10 Tf 0 0 0 rg (Daniel P. Smith) Tj /F1 10 Tf ( \(Apertus Solutions\) ) Tj /F2 10 Tf (Ross Philipson) Tj /F1 10 Tf ( \(Oracle\) ) Tj /F2 10 Tf (Krystian Hebel) Tj /F1 10 Tf ( \(3mdeb\)) Tj T* -41.27988 0 Td ET
+Q
+Q
+ 
+endstream
+endobj
+166 0 obj
+<<
+/Length 8548
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (Table of Contents) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 90.02362 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 0 633 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 .501961 rg (1   Introduction) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 633 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 615 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 .501961 rg (2   Terminology) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 615 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 597 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (2.1   Requirements Language) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 597 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 579 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (2.2   Acronyms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 579 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 561 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 .501961 rg (3   Secure Launch Architecture) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 561 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 543 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (3.1   Secure Launch aware Bootloader) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 543 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (3) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 525 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (3.1.1   Bootloader Types) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 525 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (4) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 507 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (3.2   Dynamic Launch Event Handler) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 507 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (4) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 489 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (3.3   Secure Launch Resource Table) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 489 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (4) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 471 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (3.4   Secure Launch Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 471 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (4) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 453 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (3.5   Sequence) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 453 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (5) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 435 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 .501961 rg (4   Secure Launch Interfaces) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 435 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 66.44 0 Td (5) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 417 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.1   DLE Handler Specification) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 417 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (5) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 399 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.1.1   Platform Requirements) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 399 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (5) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 381 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.2   SLRT Specification) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 381 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (6) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 363 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.3   Platform Requirements) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 363 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (6) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 345 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4   SLRT Structure) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 345 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (7) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 327 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.1   Versioning Scheme) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 327 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (7) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 309 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.1.1   Revision Table) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 309 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (7) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 291 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2   Core Entries) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 291 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (7) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 273 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.1   SLRT Header) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 273 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (7) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 255 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.2   SLRT Entry Header) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 255 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (7) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 237 cm
+q
+BT 1 0 0 1 80 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.2.1   SLRT Entry Tag Types) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 237 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (8) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 219 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.3   Dynamic Launch Configuration) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 219 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (8) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 201 cm
+q
+BT 1 0 0 1 80 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.3.1   Boot Loader Context) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 201 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (8) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 183 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.4   DRTM TPM Event Log) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 183 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (9) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 165 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.5   D-RTM Measurement Policy) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 165 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 66.44 0 Td (9) Tj T* -66.44 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 147 cm
+q
+BT 1 0 0 1 80 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.5.1   DRTM Policy Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 147 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (10) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 129 cm
+q
+BT 1 0 0 1 100 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.5.1.1   D-RTM Policy Entry Entity Types) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 129 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (10) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 111 cm
+q
+BT 1 0 0 1 100 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.2.5.1.2   D-RTM Policy Entry Flags) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 111 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (10) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 93 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.3   Intel TXT Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 93 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (11) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 75 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.3.1   Intel TXT Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 75 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (11) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 57 cm
+q
+BT 1 0 0 1 80 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.3.1.1   Saved MTRR State) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 57 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (11) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 39 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.4   AMD Secure Launch Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 39 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (11) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 21 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.4.1   AMD SKINIT Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 21 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (11) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 3 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.5   ARM DRTM Environments) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 3 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (12) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+Q
+Q
+ 
+endstream
+endobj
+167 0 obj
+<<
+/Length 6710
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 603.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 0 147 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.5.1   ARM Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 147 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (12) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 129 cm
+q
+BT 1 0 0 1 40 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.6   UEFI Environments) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 129 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (12) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 111 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.6.1   UEFI Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 111 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (12) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 93 cm
+q
+BT 1 0 0 1 60 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.6.2   UEFI Config) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 93 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (12) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 75 cm
+q
+BT 1 0 0 1 80 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (4.4.6.2.1   UEFI Config Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 75 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (12) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 57 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 .501961 rg (5   Appendix A: Measuring the DRTM Policy) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 57 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 60.88 0 Td (13) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 39 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (5.1   TPM Extend Operation) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 39 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (13) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 21 cm
+q
+BT 1 0 0 1 20 2 Tm 12 TL /F1 10 Tf 0 0 .501961 rg (5.2   Measuring the Policy) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 21 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 60.88 0 Td (13) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+1 0 0 1 0 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 .501961 rg (6   Appendix B: Intel TXT OS2MLE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 397.8898 3 cm
+q
+0 0 .501961 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 60.88 0 Td (14) Tj T* -60.88 0 Td ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 570.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (1   Introduction) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 468.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 86 Tm /F1 10 Tf 12 TL 1.843615 Tw (Like many cross-platform capabilities implemented by different manufacturers, each vendor may have) Tj T* 0 Tw .111751 Tw (their own unique way of implementing any one of these capabilities. Dynamic Launch is no different in this) Tj T* 0 Tw .327485 Tw (manner. To handle this, the TrenchBoot project is striving to provide a unified approach to using Dynamic) Tj T* 0 Tw 1.804269 Tw (Launch across different platforms. One aspect of Dynamic Launch that varies across platforms is the) Tj T* 0 Tw .916235 Tw (launch related data. For example, on Intel there is a series of Intel defined configuration data structures) Tj T* 0 Tw 1.062209 Tw (that must be present, as well as a user-defined data structure. Whereas on AMD, only the layout of an) Tj T* 0 Tw -0.06216 Tw (AMD Secure Loader Block \(SLB\) is defined and thus, any configuration structures are SLB implementation) Tj T* 0 Tw (specific.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 426.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 1.523555 Tw (To provide a unified experience in passing configuration and other meta-data to a TrenchBoot Secure) Tj T* 0 Tw .274597 Tw (Launch entry point for a kernel, this specification provides the platform-agnostic Secure Launch Resource) Tj T* 0 Tw (Table \(SLRT\) along with details on how it will be implemented for each platform supported.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 393.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (2   Terminology) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 363.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (2.1   Requirements Language) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 321.0236 cm
+q
+BT 1 0 0 1 0 26 Tm -0.110021 Tw 12 TL /F1 10 Tf 0 0 0 rg (The key words ) Tj /F2 10 Tf ("MUST") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("MUST NOT") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("REQUIRED") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("SHALL") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("SHALL NOT") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("SHOULD") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("SHOULD) Tj T* 0 Tw 3.60498 Tw (NOT") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("RECOMMENDED") Tj /F1 10 Tf (, ) Tj /F2 10 Tf ("MAY") Tj /F1 10 Tf (, and ) Tj /F2 10 Tf ("OPTIONAL") Tj /F1 10 Tf ( in this document are to be interpreted as) Tj T* 0 Tw (described in ) Tj 0 0 .501961 rg (RFC 2119) Tj 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 291.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (2.2   Acronyms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 279.0236 cm
+Q
+q
+1 0 0 1 62.69291 264.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 48.59937 0 Td (DCE:) Tj T* -48.59937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Dynamic Configuration Environment \() Tj /F3 10 Tf (eg. Intel ACM/AMD SLB) Tj /F1 10 Tf (\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 249.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 49.70937 0 Td (DLE:) Tj T* -49.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Dynamic Launch Event \() Tj /F3 10 Tf (eg. Intel GETSEC[SENTER]/AMD SKINIT) Tj /F1 10 Tf (\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 234.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 41.37937 0 Td (DLME:) Tj T* -41.37937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (Dynamic Launch Measured Environment \() Tj /F3 10 Tf (eg. Operating System/Hypervisor) Tj /F1 10 Tf (\)) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 219.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 40.82937 0 Td (DRTM:) Tj T* -40.82937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Dynamic Root of Trust Measurement) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 186.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (3   Secure Launch Architecture) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 156.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (3.1   Secure Launch aware Bootloader) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 126.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 1.027045 Tw (A bootloader is Secure Launch aware if it understands how to load or provide a DLE \(Dynamic Launch) Tj T* 0 Tw (Event\) Handler and configure an SLRT.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 114.0236 cm
+Q
+ 
+endstream
+endobj
+168 0 obj
+<<
+/Length 4589
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 670.0236 cm
+.960784 .960784 .862745 rg
+n 0 95 469.8898 -95 re f*
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 69 Tm  T* ET
+q
+1 0 0 1 16 64 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2.5 Tm /F4 12.5 Tf 15 TL (Note) Tj T* ET
+Q
+Q
+q
+1 0 0 1 16 16 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 1.105697 Tw (Throughout this specification the term bootloader will be used to generically refer to the sofware) Tj T* 0 Tw 1.660651 Tw (responsible for loading the OS. This may be an x86 bootloader such as GRUB, an embedded) Tj T* 0 Tw (system bootloader such as Das U-Boot, or an arbitrary UEFI OS Loader.) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+.662745 .662745 .662745 RG
+.5 w
+n 0 95 m 469.8898 95 l S
+n 0 0 m 469.8898 0 l S
+n 0 0 m 0 95 l S
+n 469.8898 0 m 469.8898 95 l S
+Q
+Q
+q
+1 0 0 1 62.69291 664.0236 cm
+Q
+q
+1 0 0 1 62.69291 637.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (3.1.1   Bootloader Types) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 619.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A Secure Launch aware bootloader can be categorized as one of three types,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 613.0236 cm
+Q
+q
+1 0 0 1 62.69291 598.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 19.14937 0 Td (monolithic:) Tj T* -19.14937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This is a bootloader that contains the DLE Handler.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 571.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 20.80937 0 Td (initializing:) Tj T* -20.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 4.715033 Tw (This is a bootloader that loads an external DLE Handler and executes a) Tj T* 0 Tw (supplemental bootloader.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 556.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 5.24937 0 Td (supplemental:) Tj T* -5.24937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This is a bootloader that is capable of calling a DLE Handler.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 526.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (3.2   Dynamic Launch Event Handler) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 472.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL .555697 Tw (The DLE Handler consumes the SLRT and invokes the platform's DLE. The Secure Launch specification) Tj T* 0 Tw 1.311984 Tw (seeks to standardize the invocation interface for the DLE Handler to be implemented by each platform) Tj T* 0 Tw 3.076647 Tw (supported by TrenchBoot. The specification provides a well-defined interface for DLE Handler and) Tj T* 0 Tw (bootloader implementors to follow to ensure interoperability between implementations.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 442.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (3.3   Secure Launch Resource Table) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 376.0236 cm
+q
+BT 1 0 0 1 0 50 Tm 1.276651 Tw 12 TL /F1 10 Tf 0 0 0 rg (The SLRT is a platform-agnostic, standard format for providing information to the DLE Handler and for) Tj T* 0 Tw .86528 Tw (passing D-RTM relevant information across the DLE to be available for use by the DCE and the DLME.) Tj T* 0 Tw .84686 Tw (The table ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be initialized by a bootloader and any subsequent bootloaders in the boot chain ) Tj /F2 10 Tf (MAY) Tj /F1 10 Tf  T* 0 Tw 1.92311 Tw (append entries to the table. While the table is designed to be implementation agnostic, the reality of) Tj T* 0 Tw (D-RTM hardware will drive a difference in the construction and setup of the table.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 346.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (3.4   Secure Launch Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 280.0236 cm
+q
+BT 1 0 0 1 0 50 Tm .178988 Tw 12 TL /F1 10 Tf 0 0 0 rg (The SL Entry \(Secure Launch Entry\) is a kernel entry point for the DLME that is aware of the intricacies of) Tj T* 0 Tw 3.873314 Tw (the platform's D-RTM implementation. Its interface is dictated by the platform's Dynamic Launch) Tj T* 0 Tw -0.017661 Tw (implementation. The SL Entry is responsible for bringing the system up from its Dynamic Launch state to a) Tj T* 0 Tw .237318 Tw (suitable state for transitioning control to the DLME kernel. Before transferring control to the standard code) Tj T* 0 Tw (path, the SL Entry ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( use the SLRT to establish an integrity assessment of the platform.) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+169 0 obj
+<<
+/Length 4665
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 747.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (3.5   Sequence) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 209.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 528 re B*
+Q
+q
+BT 1 0 0 1 0 506 Tm 12 TL /F5 10 Tf 0 0 0 rg (|             Monolithic Bootloader           |) Tj T* (|                                             |) Tj T* (|                                             |) Tj T* ( Initializing       Supplemental         DLE                          SL) Tj T* (  Bootloader         Bootloader        Handler          SLRT         Entry) Tj T* (------+-------      -----+------      ----+----      ----+----      ---+---) Tj T* (      |                  |                |              |             |) Tj T* (      |                  |                |              |             |) Tj T* (      |                                   |              |             |) Tj T* (      |           Load into Memory        |              |             |) Tj T* (      +----------------------------------) Tj (>) Tj (|              |             |) Tj T* (      |                                   |              |             |) Tj T* (      |                                   |              |             |) Tj T* (      |                  Initalize Table                 |             |) Tj T* (      +-------------------------------------------------) Tj (>) Tj (|             |) Tj T* (      |                                                  |             |) Tj T* (      |    Invoke       |                 |              |             |) Tj T* (      +----------------) Tj (>) Tj (|                 |              |             |) Tj T* (                        |     Update      |              |             |) Tj T* (                        +----------------) Tj (>) Tj (|              |             |) Tj T* (                        |                 |              |             |) Tj T* (                        |     Lookup      |              |             |) Tj T* (                        |     Handler     |              |             |) Tj T* (                        +----------------) Tj (>) Tj (|              |             |) Tj T* (                        |                 |              |             |) Tj T* (                        |     Invoke      |              |             |) Tj T* (                        +----------------) Tj (>) Tj (|              |             |) Tj T* (                                          |              |             |) Tj T* (                                          |    Read      |             |) Tj T* (                                          |    Table     |             |) Tj T* (                                          +-------------) Tj (>) Tj (|             |) Tj T* (                                          |              |             |) Tj T* (                                          |              |             |) Tj T* (                                          |                            |) Tj T* (                                          |    Dynamic Launch Event    |) Tj T* (                                          +---------------------------) Tj (>) Tj (|) Tj T* (                                                                       |) Tj T* (                                                         |             |) Tj T* (                                                         |             |) Tj T* (                                                         |     Read    |) Tj T* (                                                         |     Table   |) Tj T* (                                                         |) Tj (<) Tj (------------+) Tj T* (                                                         |             |) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 176.8236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (4   Secure Launch Interfaces) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 158.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (There are two interfaces to be defined here, the DLE Handler Specifications and the SLRT Specification.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 128.8236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (4.1   DLE Handler Specification) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 110.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The DLE Handler Specification defines the invocation interface for the DLE Handler.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 83.82362 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (4.1.1   Platform Requirements) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 76.86614 cm
+Q
+ 
+endstream
+endobj
+170 0 obj
+<<
+/Length 7921
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 753.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1) Tj /F1 10 Tf ( - x86 Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 741.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.1) Tj /F1 10 Tf ( - The DLE Handler ) Tj /F2 10 Tf (MAY) Tj /F1 10 Tf ( be invoked with the CPU in either 32bit) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 729.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL (protected mode or 64bit long mode) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 717.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.2) Tj /F1 10 Tf ( - The SLRT ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be passed to the DLE Handler in the EDI/RDI CPU) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 705.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL (register) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 693.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.3) Tj /F1 10 Tf ( - All other registers besides EDI/RDI are not guarenteed) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 681.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.4) Tj /F1 10 Tf ( - The invoking code ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( use a long jump to the DLE Handler) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 669.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.5) Tj /F1 10 Tf ( - The DLE Handler ) Tj /F2 10 Tf (SHALL NOT) Tj /F1 10 Tf ( return control on error) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 657.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL ( ) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 645.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2) Tj /F1 10 Tf ( - Arm Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 633.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2.1) Tj /F1 10 Tf ( - ) Tj /F3 10 Tf (Reserved) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 633.0236 cm
+Q
+q
+1 0 0 1 62.69291 603.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (4.2   SLRT Specification) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 573.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 1.484104 Tw (This specification details the construction of the SLRT, and how that table will be passed to a Secure) Tj T* 0 Tw (Launch entry point for each supported hardware platform.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 507.0236 cm
+q
+BT 1 0 0 1 0 50 Tm .60436 Tw 12 TL /F1 10 Tf 0 0 0 rg (The SLRT ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be initialized by a bootloader and any subsequent bootloaders in the boot chain ) Tj /F2 10 Tf (MAY) Tj /F1 10 Tf  T* 0 Tw .476098 Tw (append entries to the table. While the table is designed to be agnostic, the reality of DRTM hardware will) Tj T* 0 Tw .29061 Tw (drive differences in the construction and populating the table. Outlined here are a set of common, general) Tj T* 0 Tw 3.154269 Tw (requirements that all platforms should be able to meet. The supplemental sections will cover any) Tj T* 0 Tw (idiosyncrasies for the various platforms and environments supported.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 477.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (4.3   Platform Requirements) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 465.0236 cm
+Q
+q
+1 0 0 1 62.69291 453.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1) Tj /F1 10 Tf ( - General Requirements) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 441.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.1) Tj /F1 10 Tf ( - The SLRT ) Tj /F2 10 Tf (MUST) Tj /F1 10 Tf ( begin with the magic value ) Tj /F3 10 Tf 0 0 0 rg (0x4452544d) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 429.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.2) Tj /F1 10 Tf ( - A properly formatted SLRT ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( consist of a table header,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 417.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL (zero or more table entries, and an end entry.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 405.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.3) Tj /F1 10 Tf ( - The SLRT ) Tj /F2 10 Tf (SHOULD) Tj /F1 10 Tf ( be in contiguous physical memory.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 393.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.3.1) Tj /F1 10 Tf ( - A preallocated, fixed size table is ) Tj /F2 10 Tf (OPTIONAL) Tj /F1 10 Tf ( through the use) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 381.0236 cm
+q
+BT 1 0 0 1 30 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (of the ) Tj /F3 10 Tf 0 0 0 rg (max_size) Tj /F1 10 Tf 0 0 0 rg ( field.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 369.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (1.4) Tj /F1 10 Tf ( - The SLRT ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be aligned to a four-byte boundary.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 357.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL ( ) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 345.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2) Tj /F1 10 Tf ( - UEFI Environmnents) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 333.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2.1) Tj /F1 10 Tf ( - The SLRT ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be registed in the UEFI SystemTable.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 321.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2.1.2) Tj /F1 10 Tf ( - The GUID for registering the table ) Tj /F2 10 Tf (MUST BE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 309.0236 cm
+q
+BT 1 0 0 1 30 2 Tm 12 TL /F3 10 Tf 0 0 0 rg (877a9b2a-0385-45d1-a034-9dac9c9e565f) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 297.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2.2) Tj /F1 10 Tf ( - All UEFI OS Loaders ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( record an EFI Config record with an) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 285.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL (UEFI Config Entry for each measureable configuration action or) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 273.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL (information provide to the DLME kernel.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 261.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2.3) Tj /F1 10 Tf ( - The UEFI OS Loader is responsible for calling ExitBootServices\(\)) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 249.0236 cm
+q
+BT 1 0 0 1 30 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (SHALL) Tj /F1 10 Tf ( be responsible for calling the DLE Handler.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 237.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (2.3.1) Tj /F1 10 Tf ( - The address for the SLRT ) Tj /F2 10 Tf (MUST) Tj /F1 10 Tf ( be passed via an architecture) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 225.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (specific register.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 213.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL ( ) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 201.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (3) Tj /F1 10 Tf ( - x86 Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 189.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (3.1) Tj /F1 10 Tf ( - The SLRT ) Tj /F2 10 Tf (MUST) Tj /F1 10 Tf ( be constructed within the 4G boundary.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 177.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (3.1.1) Tj /F1 10 Tf ( - On Intel TXT platforms the location of the SLRT ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 165.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL (stored in the OS2MLE structure, see Appendix B) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 153.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (3.1.2) Tj /F1 10 Tf ( - On AMD platforms the location of the SLRT ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be stored in) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 141.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL (the Secure Kernel Loader \(SKL\) configuration table) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 129.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 30 2 Tm /F1 10 Tf 12 TL ( ) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 117.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (4) Tj /F1 10 Tf ( - Arm Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 105.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F2 10 Tf 0 0 0 rg (4.1) Tj /F1 10 Tf ( - ) Tj /F3 10 Tf (Reserved) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 105.0236 cm
+Q
+ 
+endstream
+endobj
+171 0 obj
+<<
+/Length 8894
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 747.0236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (4.4   SLRT Structure) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 705.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 1.264985 Tw (The SLRT is constructed from a header at the beginning, followed by a list of Tag-Length-Value \(TLV\)) Tj T* 0 Tw .78332 Tw (entries. Provided below is a description of the header and the possible entry types that may be found in) Tj T* 0 Tw (the table. For general portability, the definitions of each entry contain a representative C structure.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 678.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (4.4.1   Versioning Scheme) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 624.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL .258876 Tw (The SLRT supports revisioning at two depths, at the table level and at the individual entry level. The table) Tj T* 0 Tw .918935 Tw (level revision is found in the SLRT header and conveys the format of the SLRT header as well as what) Tj T* 0 Tw .846654 Tw (SLRT entries may be appear in the table. The entry level revisioning is for those that are expected may) Tj T* 0 Tw (need future expansion.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 600.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.1.1   Revision Table) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 582.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This table contains the list of versions for this revision of the specification.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 576.0236 cm
+Q
+q
+1 0 0 1 62.69291 504.0236 cm
+1 1 1 rg
+n 0 72 469.8898 -18 re f*
+.878431 .878431 .878431 rg
+n 0 54 469.8898 -18 re f*
+1 1 1 rg
+n 0 36 469.8898 -18 re f*
+.878431 .878431 .878431 rg
+n 0 18 469.8898 -18 re f*
+.960784 .960784 .862745 rg
+n 0 72 469.8898 -18 re f*
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 313.8588 57 cm
+q
+.960784 .960784 .862745 rg
+n 0 0 150.031 12 re f*
+Q
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL 55.84548 0 Td (Revision) Tj T* -55.84548 0 Td ET
+Q
+Q
+0 0 0 rg
+q
+1 0 0 1 6 39 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SLR Table) Tj T* ET
+Q
+Q
+q
+1 0 0 1 313.8588 39 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (0x01) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (D-RTM Policy Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 313.8588 21 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (0x01) Tj T* ET
+Q
+Q
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (UEFI Config Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 313.8588 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (0x01) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+0 0 0 RG
+.25 w
+n 0 54 m 469.8898 54 l S
+n 0 36 m 469.8898 36 l S
+n 0 18 m 469.8898 18 l S
+n 307.8588 0 m 307.8588 72 l S
+n 0 72 m 469.8898 72 l S
+n 0 0 m 469.8898 0 l S
+n 0 0 m 0 72 l S
+n 469.8898 0 m 469.8898 72 l S
+Q
+Q
+q
+1 0 0 1 62.69291 504.0236 cm
+Q
+q
+1 0 0 1 62.69291 477.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (4.4.2   Core Entries) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 459.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The core table entries are the set of entries that are platform and architecture agnostic.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 435.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.1   SLRT Header) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 405.0236 cm
+q
+BT 1 0 0 1 0 14 Tm 1.646235 Tw 12 TL /F1 10 Tf 0 0 0 rg (The SLRT Header ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( be located at the beginning of the table and provides the core information) Tj T* 0 Tw (regarding the construction of the table.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 399.0236 cm
+Q
+q
+1 0 0 1 62.69291 384.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 40.80937 0 Td (magic:) Tj T* -40.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (SLRT identifier, expected value is ) Tj /F3 10 Tf 0 0 0 rg (0x4452544d) Tj /F1 10 Tf 0 0 0 rg (.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 369.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 31.35937 0 Td (revision:) Tj T* -31.35937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Indentifies the SLRT specification revision used.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 354.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 12.46937 0 Td (architecture:) Tj T* -12.46937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Identifies the platform architecture and DL implementation.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 339.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 50.80937 0 Td (size:) Tj T* -50.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Total size of the table) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 324.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 25.23937 0 Td (max_size:) Tj T* -25.23937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The maximum size of the memory block.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 206.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 108 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 84 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 84 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 84 54 12 re f*
+.960784 .960784 .862745 rg
+n 114 84 6 12 re f*
+.960784 .960784 .862745 rg
+n 120 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 72 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 72 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 72 30 12 re f*
+.960784 .960784 .862745 rg
+n 90 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 96 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 60 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 60 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 48 72 12 re f*
+.960784 .960784 .862745 rg
+n 132 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 138 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 24 12 re f*
+.960784 .960784 .862745 rg
+n 84 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 90 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 90 12 re f*
+.960784 .960784 .862745 rg
+n 126 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 86 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_table) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u32) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (magic) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (revision) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (architecture) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u32) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (size) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u32) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (max_size) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (    ) Tj /F7 10 Tf .25098 .501961 .501961 rg (/* entries[] */) Tj /F5 10 Tf 0 0 0 rg  T* (8 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 182.8236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.2   SLRT Entry Header) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 152.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .063798 Tw (The SLRT is a TLV list requiring every entry to have an identifying tag and the size of the entry. The SLRT) Tj T* 0 Tw (Entry Header provides that representation and is present at the beginning of every entry.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 146.8236 cm
+Q
+q
+1 0 0 1 62.69291 131.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.70937 0 Td (tag:) Tj T* -54.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Entry identifier.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 116.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 50.80937 0 Td (size:) Tj T* -50.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Size of the entry.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+ 
+endstream
+endobj
+172 0 obj
+<<
+/Length 10467
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 703.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 60 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 36 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 36 78 12 re f*
+.960784 .960784 .862745 rg
+n 138 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 144 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 78 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 84 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 12 24 12 re f*
+.960784 .960784 .862745 rg
+n 84 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 90 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 38 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (tag) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (size) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 679.8236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.2.1   SLRT Entry Tag Types) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 661.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The list of valid entry tags.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 520.6236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 132 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 108 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 108 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 96 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 96 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 84 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 72 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 270 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 18 12 re f*
+BT 1 0 0 1 0 110 Tm 12 TL /F5 10 Tf 0 0 0 rg ( 1 ) Tj 0 0 0 rg (#define SLR_ENTRY_INVALID           0x0000) Tj 0 0 0 rg  T* ( 2 ) Tj 0 0 0 rg (#define SLR_ENTRY_DL_INFO           0x0001) Tj 0 0 0 rg  T* ( 3 ) Tj 0 0 0 rg (#define SLR_ENTRY_LOG_INFO          0x0002) Tj 0 0 0 rg  T* ( 4 ) Tj 0 0 0 rg (#define SLR_ENTRY_DRTM_POLICY       0x0003) Tj 0 0 0 rg  T* ( 5 ) Tj 0 0 0 rg (#define SLR_ENTRY_INTEL_INFO        0x0004) Tj 0 0 0 rg  T* ( 6 ) Tj 0 0 0 rg (#define SLR_ENTRY_AMD_INFO          0x0005) Tj 0 0 0 rg  T* ( 7 ) Tj 0 0 0 rg (#define SLR_ENTRY_ARM_INFO          0x0006) Tj 0 0 0 rg  T* ( 8 ) Tj 0 0 0 rg (#define SLR_ENTRY_UEFI_INFO         0x0007) Tj 0 0 0 rg  T* ( 9 ) Tj 0 0 0 rg (#define SLR_ENTRY_UEFI_CONFIG       0x0008) Tj 0 0 0 rg  T* (10 ) Tj 0 0 0 rg (#define SLR_ENTRY_END               0xffff) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 496.6236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.3   Dynamic Launch Configuration) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 484.6236 cm
+Q
+q
+1 0 0 1 62.69291 469.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 16.92937 0 Td (REQUIRED:) Tj T* -16.92937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This entry ) Tj /F2 10 Tf (MUST) Tj /F1 10 Tf ( be present.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 439.6236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL -0.123765 Tw (This is the main configuration entry, providing the necessary information to invoke the DLE Handler and for) Tj T* 0 Tw (the DLE Handler to invoke the DL.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 433.6236 cm
+Q
+q
+1 0 0 1 62.69291 418.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.70937 0 Td (tag:) Tj T* -54.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SLR_ENTRY_DL_INFO) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 403.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 19.69937 0 Td (bl_context:) Tj T* -19.69937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Allows the bootloader to provide a reference to a context object.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 388.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 19.13937 0 Td (dl_handler:) Tj T* -19.13937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The address to the entry point for the DLE Handler.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 373.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 24.12937 0 Td (dce_base:) Tj T* -24.12937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The base address where the DCE is located.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 358.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 28.01937 0 Td (dce_size:) Tj T* -28.01937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The size of the DCE.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 343.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 16.35937 0 Td (dlme_entry:) Tj T* -16.35937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The address for the entry point of the DLME.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 226.4236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 108 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 84 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 84 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 84 102 12 re f*
+.960784 .960784 .862745 rg
+n 162 84 6 12 re f*
+.960784 .960784 .862745 rg
+n 168 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 72 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 72 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 72 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 72 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 60 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 60 84 12 re f*
+.960784 .960784 .862745 rg
+n 168 60 60 12 re f*
+.960784 .960784 .862745 rg
+n 228 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 234 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 48 60 12 re f*
+.960784 .960784 .862745 rg
+n 120 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 126 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 12 60 12 re f*
+.960784 .960784 .862745 rg
+n 120 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 126 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 86 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_dl_info) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_bl_context) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (bl_context) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (dl_handler) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (dce_base) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u32) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (dce_size) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (dlme_entry) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (8 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 202.4236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.3.1   Boot Loader Context) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 172.4236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 1.472485 Tw (There may be a situation where the bootloader will need to leave a context object containing platform) Tj T* 0 Tw (specific information or helper callbacks for the DLE Handler to use.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 160.4236 cm
+Q
+q
+1 0 0 1 62.69291 76.86614 cm
+.960784 .960784 .862745 rg
+n 0 83.55748 469.8898 -83.55748 re f*
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 57.55748 Tm  T* ET
+q
+1 0 0 1 16 52.55748 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2.5 Tm /F4 12.5 Tf 15 TL (Note) Tj T* ET
+Q
+Q
+q
+1 0 0 1 16 4.55748 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL -0.06668 Tw (It is out-of-scope for this specification, but it is advised that if a platform or a bootloader requires the) Tj T* 0 Tw 1.141412 Tw (use of a context object, they should standardize their context object to enable independent DLE) Tj T* 0 Tw (Handlers) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+.662745 .662745 .662745 RG
+.5 w
+n 0 83.55748 m 469.8898 83.55748 l S
+n 0 0 m 469.8898 0 l S
+n 0 0 m 0 83.55748 l S
+n 469.8898 0 m 469.8898 83.55748 l S
+Q
+Q
+ 
+endstream
+endobj
+173 0 obj
+<<
+/Length 9531
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 759.0236 cm
+Q
+q
+1 0 0 1 62.69291 753.0236 cm
+Q
+q
+1 0 0 1 62.69291 738.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 18.03937 0 Td (bootloader:) Tj T* -18.03937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (An identifier the bootloader should use for ident and version.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 723.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 34.14937 0 Td (context:) Tj T* -34.14937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Address of the context object.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 641.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 72 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 48 84 12 re f*
+.960784 .960784 .862745 rg
+n 144 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 150 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 60 12 re f*
+.960784 .960784 .862745 rg
+n 120 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 126 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 12 42 12 re f*
+.960784 .960784 .862745 rg
+n 102 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 108 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 50 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_bl_context) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (bootloader) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (reserved) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (context) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 617.8236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.4   DRTM TPM Event Log) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 605.8236 cm
+Q
+q
+1 0 0 1 62.69291 590.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 16.92937 0 Td (REQUIRED:) Tj T* -16.92937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This entry ) Tj /F2 10 Tf (MUST) Tj /F1 10 Tf ( be present.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 572.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (This entry describes where and what type of TPM event log should be used.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 560.8236 cm
+Q
+q
+1 0 0 1 62.69291 465.8236 cm
+.960784 .960784 .862745 rg
+n 0 95 469.8898 -95 re f*
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 69 Tm  T* ET
+q
+1 0 0 1 16 64 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2.5 Tm /F4 12.5 Tf 15 TL (Note) Tj T* ET
+Q
+Q
+q
+1 0 0 1 16 16 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL 1.38561 Tw (On most platforms, the TCG UEFI TPM event log format should be used. The ability to specify) Tj T* 0 Tw .452339 Tw (alternatives is to support older platforms that are not aware of the modern event log format or can) Tj T* 0 Tw (support multiple formats.) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+.662745 .662745 .662745 RG
+.5 w
+n 0 95 m 469.8898 95 l S
+n 0 0 m 469.8898 0 l S
+n 0 0 m 0 95 l S
+n 469.8898 0 m 469.8898 95 l S
+Q
+Q
+q
+1 0 0 1 62.69291 459.8236 cm
+Q
+q
+1 0 0 1 62.69291 453.8236 cm
+Q
+q
+1 0 0 1 62.69291 438.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.70937 0 Td (tag:) Tj T* -54.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SLR_ENTRY_LOG_INFO) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 423.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 38.59937 0 Td (format:) Tj T* -38.59937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The type of TPM event log format to use.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 408.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 48.03937 0 Td (addr:) Tj T* -48.03937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The base address where the log should reside.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 393.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 50.80937 0 Td (size:) Tj T* -50.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The size allocated for the log.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 288.6236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 96 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 72 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 72 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 72 108 12 re f*
+.960784 .960784 .862745 rg
+n 168 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 174 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 60 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 60 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 60 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 96 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 102 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 24 12 re f*
+.960784 .960784 .862745 rg
+n 84 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 90 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 12 24 12 re f*
+.960784 .960784 .862745 rg
+n 84 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 90 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 74 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_log_info) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (format) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (reserved) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (addr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u32) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (size) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 264.6236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.5   D-RTM Measurement Policy) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 252.6236 cm
+Q
+q
+1 0 0 1 62.69291 237.6236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 16.92937 0 Td (REQUIRED:) Tj T* -16.92937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This entry ) Tj /F2 10 Tf (MUST) Tj /F1 10 Tf ( be present and have the required entries.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 195.6236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL .599987 Tw (The measurement policy is for conveying to the SL Entry on what it should measure, where that entity is) Tj T* 0 Tw -0.118249 Tw (located, which PCR the measurement should be stored, and how the event should be identified in the TPM) Tj T* 0 Tw (event log.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 183.6236 cm
+Q
+q
+1 0 0 1 62.69291 112.6236 cm
+.960784 .960784 .862745 rg
+n 0 71 469.8898 -71 re f*
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+BT 1 0 0 1 6 45 Tm  T* ET
+q
+1 0 0 1 16 40 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2.5 Tm /F4 12.5 Tf 15 TL (Warning) Tj T* ET
+Q
+Q
+q
+1 0 0 1 16 16 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (The SL Entry ) Tj /F2 10 Tf (SHALL) Tj /F1 10 Tf ( fail if it determines an invalid policy is present.) Tj T* ET
+Q
+Q
+q
+1 J
+1 j
+.662745 .662745 .662745 RG
+.5 w
+n 0 71 m 469.8898 71 l S
+n 0 0 m 469.8898 0 l S
+n 0 0 m 0 71 l S
+n 469.8898 0 m 469.8898 71 l S
+Q
+Q
+q
+1 0 0 1 62.69291 106.6236 cm
+Q
+q
+1 0 0 1 62.69291 100.6236 cm
+Q
+q
+1 0 0 1 62.69291 85.62362 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.70937 0 Td (tag:) Tj T* -54.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SLR_ENTRY_ENTRY_POLICY) Tj T* ET
+Q
+Q
+q
+Q
+Q
+ 
+endstream
+endobj
+174 0 obj
+<<
+/Length 11210
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 750.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 31.35937 0 Td (revision:) Tj T* -31.35937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A revision field to identify the version of policy being used.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 735.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 21.35937 0 Td (nr_entries:) Tj T* -21.35937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The total number of policy entries available.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 641.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 84 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 60 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 60 96 12 re f*
+.960784 .960784 .862745 rg
+n 156 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 162 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 48 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 60 12 re f*
+.960784 .960784 .862745 rg
+n 120 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 126 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 132 12 re f*
+.960784 .960784 .862745 rg
+n 168 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 62 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_policy) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (revision) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (nr_entries) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (    ) Tj /F7 10 Tf .25098 .501961 .501961 rg (/* policy_entries[] */) Tj /F5 10 Tf 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 617.8236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.5.1   DRTM Policy Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 575.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 26 Tm /F1 10 Tf 12 TL .038488 Tw (A policy entry represents an entity that the SL Entry is being requested to measure. As an SL Entry is able) Tj T* 0 Tw 1.417633 Tw (to measure an attribute of the launch environment, that attribute will be published as an entity type. A) Tj T* 0 Tw (generic "unspecified" entity type is also available for measuring a range of memory.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 569.8236 cm
+Q
+q
+1 0 0 1 62.69291 554.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.14937 0 Td (pcr:) Tj T* -54.14937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (PCR to store the measurement.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 539.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 16.91937 0 Td (entity_type:) Tj T* -16.91937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Identifies the entity type of the entry.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 524.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 46.36937 0 Td (flags:) Tj T* -46.36937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Flag field to store state for this entry.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 509.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 43.03937 0 Td (entity:) Tj T* -43.03937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The address to measure.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 494.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 50.80937 0 Td (size:) Tj T* -50.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The size of entity if not flagged as implicit.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 479.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 31.36937 0 Td (evt_info:) Tj T* -31.36937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Label to be recorded in TPM Event Log.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 350.6236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 120 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 96 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 96 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 96 96 12 re f*
+.960784 .960784 .862745 rg
+n 156 96 6 12 re f*
+.960784 .960784 .862745 rg
+n 162 96 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 84 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 84 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 84 18 12 re f*
+.960784 .960784 .862745 rg
+n 78 84 6 12 re f*
+.960784 .960784 .862745 rg
+n 84 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 72 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 72 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 72 66 12 re f*
+.960784 .960784 .862745 rg
+n 126 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 132 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 60 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 60 30 12 re f*
+.960784 .960784 .862745 rg
+n 90 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 96 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 48 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 36 12 re f*
+.960784 .960784 .862745 rg
+n 96 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 102 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 24 12 re f*
+.960784 .960784 .862745 rg
+n 84 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 90 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 24 12 re f*
+.960784 .960784 .862745 rg
+n 66 12 48 12 re f*
+.960784 .960784 .862745 rg
+n 114 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 120 12 126 12 re f*
+.960784 .960784 .862745 rg
+n 246 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 258 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 98 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_policy_entry) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (pcr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (entity_type) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (flags) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (reserved) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (entity) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (size) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (8 ) Tj 0 0 0 rg (    ) Tj .690196 0 .25098 rg (char) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (evt_info) Tj 0 0 0 rg ([) Tj 0 0 0 rg (TPM_EVENT_INFO_LENGTH) Tj 0 0 0 rg (];) Tj 0 0 0 rg  T* (9 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 326.6236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.5.1.1   D-RTM Policy Entry Entity Types) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 308.6236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The list of valid entity types for D-RTM Policy entries.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 179.4236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 120 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 96 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 96 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 84 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 72 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 216 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+BT 1 0 0 1 0 98 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj 0 0 0 rg (#define SLR_ET_UNSPECIFIED  0x0000) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (#define SLR_ET_SLRT         0x0001) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (#define SLR_ET_BOOT_PARAMS  0x0002) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (#define SLR_ET_SETUP_DATA   0x0003) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (#define SLR_ET_CMDLINE      0x0004) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (#define SLR_ET_UEFI_MEMMAP  0x0005) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (#define SLR_ET_RAMDISK      0x0006) Tj 0 0 0 rg  T* (8 ) Tj 0 0 0 rg (#define SLR_ET_TXT_OS2MLE   0x0010) Tj 0 0 0 rg  T* (9 ) Tj 0 0 0 rg (#define SLR_ET_UNUSED       0xffff) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 155.4236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.2.5.1.2   D-RTM Policy Entry Flags) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 137.4236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The list of valid flags for D-RTM Policy entries.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 92.22362 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 36 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 246 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+BT 1 0 0 1 0 14 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj 0 0 0 rg (#define SLR_POLICY_FLAG_MEASURED    0x1) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (#define SLR_POLICY_IMPLICIT_SIZE    0x2) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+ 
+endstream
+endobj
+175 0 obj
+<<
+/Length 10246
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 750.0236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (4.4.3   Intel TXT Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 732.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (When on Intel platforms specific information needs to be conveyed to Secure Launch.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 708.0236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.3.1   Intel TXT Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 696.0236 cm
+Q
+q
+1 0 0 1 62.69291 681.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 16.92937 0 Td (REQUIRED:) Tj T* -16.92937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This entry ) Tj /F2 10 Tf (MUST) Tj /F1 10 Tf ( be present on Intel platforms.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 651.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .08561 Tw (Intel TXT requires for the pre-launch environment to pass MSR and MTRR state across to the post-launch) Tj T* 0 Tw (environment.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 645.0236 cm
+Q
+q
+1 0 0 1 62.69291 630.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.70937 0 Td (tag:) Tj T* -54.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SLR_ENTRY_INTEL_INFO) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 603.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F2 10 Tf 12 TL 5.21937 0 Td (saved_misc_e) Tj T* 14.47 0 Td (nable_msr:) Tj T* -19.68937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Saved MSR values) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 576.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F2 10 Tf 12 TL 3.56937 0 Td (saved_bsp_mt) Tj T* 52.8 0 Td (rrs:) Tj T* -56.36937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Saved BSP MTRRs) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 494.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 72 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 48 120 12 re f*
+.960784 .960784 .862745 rg
+n 180 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 36 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 126 12 re f*
+.960784 .960784 .862745 rg
+n 186 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 192 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 12 84 12 re f*
+.960784 .960784 .862745 rg
+n 168 12 90 12 re f*
+.960784 .960784 .862745 rg
+n 258 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 264 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 50 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_intel_info) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (saved_misc_enable_msr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (txt_mtrr_state) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (saved_bsp_mtrrs) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 470.8236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.3.1.1   Saved MTRR State) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 452.8236 cm
+q
+.960784 .960784 .862745 rg
+n 0 0 36 12 re f*
+.960784 .960784 .862745 rg
+n 36 0 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 0 108 12 re f*
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (struct) Tj ( ) Tj (slr_txt_mtrr_state) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 446.8236 cm
+Q
+q
+1 0 0 1 62.69291 419.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F2 10 Tf 12 TL 2.46937 0 Td (default_mem_t) Tj T* 50.01 0 Td (ype:) Tj T* -52.47937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The default memory type for regions not covered by an MTRR) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 404.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 23.58937 0 Td (mtrr_vcnt:) Tj T* -23.58937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Number of variable MTRR pairs in the mtrr_vcnt array) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 389.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 25.80937 0 Td (mtrr_pair:) Tj T* -25.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Array of variable MTRR pairs to restore post launch) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 371.8236 cm
+q
+.960784 .960784 .862745 rg
+n 0 0 36 12 re f*
+.960784 .960784 .862745 rg
+n 36 0 6 12 re f*
+.960784 .960784 .862745 rg
+n 42 0 102 12 re f*
+BT 1 0 0 1 0 2 Tm 12 TL /F5 10 Tf 0 0 0 rg (struct) Tj ( ) Tj (slr_txt_mtrr_pair) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 365.8236 cm
+Q
+q
+1 0 0 1 62.69291 338.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F2 10 Tf 12 TL 1.34937 0 Td (mtrr_physbase) Tj T* 68.36 0 Td (:) Tj T* -69.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Physical base address for variable MTRR) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 311.8236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F2 10 Tf 12 TL 4.12937 0 Td (mtrr_physmas) Tj T* 60.02 0 Td (k:) Tj T* -64.14937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 15 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Physical mask for the variable MTRR) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 170.6236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 132 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 108 18 12 re f*
+.960784 .960784 .862745 rg
+n 18 108 36 12 re f*
+.960784 .960784 .862745 rg
+n 60 108 102 12 re f*
+.960784 .960784 .862745 rg
+n 168 108 6 12 re f*
+.960784 .960784 .862745 rg
+n 174 108 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 96 18 12 re f*
+.960784 .960784 .862745 rg
+n 42 96 18 12 re f*
+.960784 .960784 .862745 rg
+n 66 96 78 12 re f*
+.960784 .960784 .862745 rg
+n 144 96 6 12 re f*
+.960784 .960784 .862745 rg
+n 150 96 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 84 18 12 re f*
+.960784 .960784 .862745 rg
+n 42 84 18 12 re f*
+.960784 .960784 .862745 rg
+n 66 84 78 12 re f*
+.960784 .960784 .862745 rg
+n 144 84 6 12 re f*
+.960784 .960784 .862745 rg
+n 150 84 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 72 18 12 re f*
+.960784 .960784 .862745 rg
+n 18 72 12 12 re f*
+.960784 .960784 .862745 rg
+n 30 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 18 12 re f*
+.960784 .960784 .862745 rg
+n 18 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 18 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 60 48 108 12 re f*
+.960784 .960784 .862745 rg
+n 174 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 180 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 42 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 66 36 96 12 re f*
+.960784 .960784 .862745 rg
+n 162 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 168 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 42 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 66 24 54 12 re f*
+.960784 .960784 .862745 rg
+n 120 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 126 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 42 12 36 12 re f*
+.960784 .960784 .862745 rg
+n 84 12 78 12 re f*
+.960784 .960784 .862745 rg
+n 168 12 54 12 re f*
+.960784 .960784 .862745 rg
+n 222 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 228 12 150 12 re f*
+.960784 .960784 .862745 rg
+n 378 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 390 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 18 12 re f*
+.960784 .960784 .862745 rg
+n 18 0 12 12 re f*
+BT 1 0 0 1 0 110 Tm 12 TL /F5 10 Tf 0 0 0 rg ( 1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_txt_mtrr_pair) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* ( 2 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (mtrr_physbase) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* ( 3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (mtrr_physmask) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* ( 4 ) Tj 0 0 0 rg (};) Tj 0 0 0 rg  T* ( 5 ) Tj 0 0 0 rg  T* ( 6 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_txt_mtrr_state) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* ( 7 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (default_mem_type) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* ( 8 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (mtrr_vcnt) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* ( 9 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (txt_mtrr_pair) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (mtrr_pair) Tj 0 0 0 rg ([) Tj 0 0 0 rg (TXT_VARIABLE_MTRRS_LENGTH) Tj 0 0 0 rg (];) Tj 0 0 0 rg  T* (10 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 143.6236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (4.4.4   AMD Secure Launch Platforms) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 119.6236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.4.1   AMD SKINIT Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 101.6236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A placeholder for info specific to AMD SKINIT.) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+176 0 obj
+<<
+/Length 10146
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 715.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 48 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 24 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 24 108 12 re f*
+.960784 .960784 .862745 rg
+n 168 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 174 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 12 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_amd_info) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 688.8236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (4.4.5   ARM DRTM Environments) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 664.8236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.5.1   ARM Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 646.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A placeholder for info specific to ARM D-RTM environments.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 589.6236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 48 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 24 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 24 108 12 re f*
+.960784 .960784 .862745 rg
+n 168 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 174 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 12 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_arm_info) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 562.6236 cm
+q
+BT 1 0 0 1 0 2.5 Tm 15 TL /F4 12.5 Tf 0 0 0 rg (4.4.6   UEFI Environments) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 532.6236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .532651 Tw (To support UEFI bootloaders that may do additional configuration of the Secure Launch kernel, the UEFI) Tj T* 0 Tw (SLRT entries provide a means to convey any operational configurations they may have done.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 508.6236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.6.1   UEFI Info) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 490.6236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A placeholder for info specific to UEFI environments.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 433.4236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 48 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 24 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 24 114 12 re f*
+.960784 .960784 .862745 rg
+n 174 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 180 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 12 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 12 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 26 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_uefi_info) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 409.4236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.6.2   UEFI Config) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 397.4236 cm
+Q
+q
+1 0 0 1 62.69291 382.4236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 18.03937 0 Td (OPTIONAL:) Tj T* -18.03937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This entry ) Tj /F2 10 Tf (SHOULD) Tj /F1 10 Tf ( be present on UEFI systems.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 352.4236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL 2.553735 Tw (This entry can be considered a D-RTM measurement policy for UEFI. It will declare that the UEFI) Tj T* 0 Tw (bootloader has made configurations changes that should be measured.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 346.4236 cm
+Q
+q
+1 0 0 1 62.69291 331.4236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.70937 0 Td (tag:) Tj T* -54.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (SLR_ENTRY_UEFI_CONFIG) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 316.4236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 31.35937 0 Td (revision:) Tj T* -31.35937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A revision field to identify the version of config being used.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 301.4236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 21.35937 0 Td (nr_entries:) Tj T* -21.35937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The total number of configuration entries present.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 208.2236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 84 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 60 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 60 126 12 re f*
+.960784 .960784 .862745 rg
+n 186 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 192 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 48 78 12 re f*
+.960784 .960784 .862745 rg
+n 162 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 180 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 186 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 60 12 re f*
+.960784 .960784 .862745 rg
+n 120 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 126 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 168 12 re f*
+.960784 .960784 .862745 rg
+n 204 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 12 12 re f*
+BT 1 0 0 1 0 62 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_uefi_config) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_entry_hdr) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (hdr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (revision) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (nr_entries) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (    ) Tj /F7 10 Tf .25098 .501961 .501961 rg (/* slr_uefi_cfg_entries[] */) Tj /F5 10 Tf 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (};) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 184.2236 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F4 10 Tf 0 0 0 rg (4.4.6.2.1   UEFI Config Entry) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 172.2236 cm
+Q
+q
+1 0 0 1 62.69291 157.2236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 18.03937 0 Td (OPTIONAL:) Tj T* -18.03937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+BT 1 0 0 1 0 2 Tm 12 TL /F1 10 Tf 0 0 0 rg (This entry ) Tj /F2 10 Tf (SHOULD) Tj /F1 10 Tf ( be present on UEFI systems.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 139.2236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (A config entry represents an entity that the UEFI bootloader is requesting to be measured.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 133.2236 cm
+Q
+q
+1 0 0 1 62.69291 118.2236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.14937 0 Td (pcr:) Tj T* -54.14937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (PCR to store the measurement.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 103.2236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.70937 0 Td (cfg:) Tj T* -54.70937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The address or value to measure.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 88.22362 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 50.80937 0 Td (size:) Tj T* -50.80937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The size to measure.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+ 
+endstream
+endobj
+177 0 obj
+<<
+/Length 7956
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 750.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 31.36937 0 Td (evt_info:) Tj T* -31.36937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Label to be recorded in TPM Event Log.) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 644.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 96 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 72 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 72 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 72 108 12 re f*
+.960784 .960784 .862745 rg
+n 168 72 6 12 re f*
+.960784 .960784 .862745 rg
+n 174 72 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 60 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 60 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 60 18 12 re f*
+.960784 .960784 .862745 rg
+n 78 60 6 12 re f*
+.960784 .960784 .862745 rg
+n 84 60 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 48 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 48 48 12 re f*
+.960784 .960784 .862745 rg
+n 108 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 114 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 78 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 90 36 132 12 re f*
+.960784 .960784 .862745 rg
+n 222 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 24 24 12 re f*
+.960784 .960784 .862745 rg
+n 84 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 90 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 24 12 re f*
+.960784 .960784 .862745 rg
+n 66 12 48 12 re f*
+.960784 .960784 .862745 rg
+n 114 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 120 12 126 12 re f*
+.960784 .960784 .862745 rg
+n 246 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 258 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 6 12 re f*
+.960784 .960784 .862745 rg
+n 24 0 48 12 re f*
+.960784 .960784 .862745 rg
+n 72 0 6 12 re f*
+BT 1 0 0 1 0 74 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_uefi_cfg_entry) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (pcr) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u16) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (reserved) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u64) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (cfg) Tj 0 0 0 rg (;) Tj 0 0 0 rg ( ) Tj /F7 10 Tf .25098 .501961 .501961 rg (/* address or value */) Tj /F5 10 Tf 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u32) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (size) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (6 ) Tj 0 0 0 rg (    ) Tj .690196 0 .25098 rg (char) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (evt_info) Tj 0 0 0 rg ([) Tj 0 0 0 rg (TPM_EVENT_INFO_LENGTH) Tj 0 0 0 rg (];) Tj 0 0 0 rg  T* (7 ) Tj 0 0 0 rg (}) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (__packed) Tj 0 0 0 rg (;) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 611.8236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (5   Appendix A: Measuring the DRTM Policy) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 545.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 50 Tm /F1 10 Tf 12 TL .219461 Tw (While the D-RTM TPM event log is itself proof of the D-RTM policy used by Secure Launch, there may be) Tj T* 0 Tw .466235 Tw (motivation for the policy itself to be incorporated into the measurement chain. While this section does not) Tj T* 0 Tw 3.053984 Tw (address the possible motivations or the validity of those motivations, a possible use of the policy) Tj T* 0 Tw -0.053765 Tw (measurement can be used as the value to cap the D-RTM PCRs. Regardless of motivations, this appendix) Tj T* 0 Tw (is to provide guidance on how the policy might be measured in a meaningful way.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 515.8236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (5.1   TPM Extend Operation) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 485.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 14 Tm /F1 10 Tf 12 TL .778735 Tw (For clarity, the extend operation, denoted here on out as E\(\), is an order preserving, recursive, mapping) Tj T* 0 Tw (function. Consider any hash function, denoted as H\(\), the extend operation, is defined as:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 479.8236 cm
+Q
+q
+1 0 0 1 62.69291 467.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 15 2 Tm /F1 10 Tf 12 TL (Given,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 455.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (0 = sizeof\(H\) bytes of 0) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 443.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (Objs = [ Obj_0, ..., Obj_n ]) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 431.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 15 2 Tm /F1 10 Tf 12 TL (Then,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 419.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (E\(Objs\) = {) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 407.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 55 2 Tm /F1 10 Tf 12 TL (E_0 = H\( 0 | H\(Obj_0\) \)) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 395.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 55 2 Tm /F1 10 Tf 12 TL (E_n = H\( E_\(n-1\) | H\(Obj_n\) \)) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 383.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (}) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 383.8236 cm
+Q
+q
+1 0 0 1 62.69291 353.8236 cm
+q
+BT 1 0 0 1 0 3 Tm 18 TL /F2 15 Tf 0 0 0 rg (5.2   Measuring the Policy) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 299.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL .632209 Tw (Measuring the policy is not as simple as hashing the block of memory containing the policy. This will not) Tj T* 0 Tw .134987 Tw (work as the policy may contain memory addresses that have the potential to change on the next launch of) Tj T* 0 Tw .233488 Tw (the system. As a result there is a potential for the next launch not to have the same memory addresses in) Tj T* 0 Tw (the policy, which would in turn render a different measurement.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 221.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 62 Tm /F1 10 Tf 12 TL -0.05439 Tw (To make a meaningful measurement of the policy, the measurement must capture what entities were to be) Tj T* 0 Tw 1.36936 Tw (measured and what order they were to be measured. To capture the first half, the measurement must) Tj T* 0 Tw .276651 Tw (contain enough of a DRTM policy entry to capture its uniqueness. Considering DRTM Policy Entry above,) Tj T* 0 Tw 1.974104 Tw (a combination of PCR, Entity Type, and Event Info yields a unique identity for the entry. To capture) Tj T* 0 Tw .503876 Tw (ordering of the policy events, the extend operation can be used to render a unique value that reflects the) Tj T* 0 Tw (order of the policy events.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 203.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Using this logic, the resulting operation to measure the policy would be as:) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 197.8236 cm
+Q
+q
+1 0 0 1 62.69291 185.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 15 2 Tm /F1 10 Tf 12 TL (Given,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 173.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (Entry_n = PCR_n | EntityType_n | EventInfo_n) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 161.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (Policy = [ Entry_0, ..., Entry_n ]) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 149.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 15 2 Tm /F1 10 Tf 12 TL (Then,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 137.8236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 35 2 Tm /F1 10 Tf 12 TL (M_policy = E\(Policy\)) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 137.8236 cm
+Q
+q
+1 0 0 1 62.69291 107.8236 cm
+q
+BT 1 0 0 1 0 14 Tm .236807 Tw 12 TL /F1 10 Tf 0 0 0 rg (The result, ) Tj /F3 10 Tf 0 0 0 rg (M_policy) Tj /F1 10 Tf 0 0 0 rg (, will be a hash of the policy that can then be extended into one, or more if using as a) Tj T* 0 Tw (cap value, PCR\(s\).) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+178 0 obj
+<<
+/Length 4102
+>>
+stream
+1 0 0 1 0 0 cm  BT /F1 12 Tf 14.4 TL ET
+q
+1 0 0 1 62.69291 744.0236 cm
+q
+BT 1 0 0 1 0 3.5 Tm 21 TL /F2 17.5 Tf 0 0 0 rg (6   Appendix B: Intel TXT OS2MLE) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 690.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 38 Tm /F1 10 Tf 12 TL .811412 Tw (The Intel TXT specification[1] provides a provision for the pre-launch environment to pass information to) Tj T* 0 Tw 3.649982 Tw (the post-launch environment. The specification does not define this structure, leaving that to the) Tj T* 0 Tw .352765 Tw (implementation, but provides an allocation for it in the TXT Heap definition. This area is referred to as the) Tj T* 0 Tw (OS2MLE structure.) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 672.0236 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (The OS2MLE structure for Secure Launch is defined as follows,) Tj T* ET
+Q
+Q
+q
+1 0 0 1 62.69291 666.0236 cm
+Q
+q
+1 0 0 1 62.69291 651.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 34.13937 0 Td (version:) Tj T* -34.13937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Revision of the os2mle table) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 636.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 54.14937 0 Td (slrt:) Tj T* -54.14937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Pointer to the SLRT) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 621.0236 cm
+0 0 0 rg
+BT /F1 10 Tf 12 TL ET
+q
+1 0 0 1 6 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F2 10 Tf 12 TL 11.34937 0 Td (mle_scratch:) Tj T* -11.34937 0 Td ET
+Q
+Q
+q
+1 0 0 1 91.03937 3 cm
+q
+0 0 0 rg
+BT 1 0 0 1 0 2 Tm /F1 10 Tf 12 TL (Scratch area for use by SL Entry early code) Tj T* ET
+Q
+Q
+q
+Q
+Q
+q
+1 0 0 1 62.69291 539.8236 cm
+q
+q
+1 0 0 1 0 0 cm
+q
+1 0 0 1 6.6 6.6 cm
+q
+.662745 .662745 .662745 RG
+.5 w
+.960784 .960784 .862745 rg
+n -6 -6 468.6898 72 re B*
+Q
+q
+.960784 .960784 .862745 rg
+n 0 48 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 54 48 36 12 re f*
+.960784 .960784 .862745 rg
+n 96 48 6 12 re f*
+.960784 .960784 .862745 rg
+n 102 48 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 36 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 36 18 12 re f*
+.960784 .960784 .862745 rg
+n 60 36 42 12 re f*
+.960784 .960784 .862745 rg
+n 102 36 6 12 re f*
+.960784 .960784 .862745 rg
+n 108 36 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 24 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 24 36 12 re f*
+.960784 .960784 .862745 rg
+n 78 24 54 12 re f*
+.960784 .960784 .862745 rg
+n 138 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 144 24 24 12 re f*
+.960784 .960784 .862745 rg
+n 168 24 6 12 re f*
+.960784 .960784 .862745 rg
+n 174 24 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 36 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 54 12 66 12 re f*
+.960784 .960784 .862745 rg
+n 120 12 6 12 re f*
+.960784 .960784 .862745 rg
+n 126 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 138 12 12 12 re f*
+.960784 .960784 .862745 rg
+n 150 12 0 12 re f*
+.960784 .960784 .862745 rg
+n 0 0 12 12 re f*
+.960784 .960784 .862745 rg
+n 12 0 6 12 re f*
+BT 1 0 0 1 0 50 Tm 12 TL /F5 10 Tf 0 0 0 rg (1 ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (os2mle) Tj 0 0 0 rg ( ) Tj 0 0 0 rg ({) Tj 0 0 0 rg  T* (2 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u32) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (version) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (3 ) Tj 0 0 0 rg (    ) Tj /F6 10 Tf 0 .501961 0 rg (struct) Tj /F5 10 Tf 0 0 0 rg ( ) Tj 0 0 0 rg (slr_table) Tj 0 0 0 rg ( ) Tj .4 .4 .4 rg (*) Tj 0 0 0 rg (slrt) Tj 0 0 0 rg (;) Tj 0 0 0 rg  T* (4 ) Tj 0 0 0 rg (    ) Tj 0 0 0 rg (u8) Tj 0 0 0 rg ( ) Tj 0 0 0 rg (mle_scratch) Tj 0 0 0 rg ([) Tj .4 .4 .4 rg (64) Tj 0 0 0 rg (];) Tj 0 0 0 rg  T* (5 ) Tj 0 0 0 rg (}) Tj T* ET
+Q
+Q
+Q
+Q
+Q
+q
+1 0 0 1 62.69291 507.8236 cm
+q
+BT 1 0 0 1 0 14 Tm 3.579764 Tw 12 TL /F1 10 Tf 0 0 0 rg ([1] ) Tj 0 0 .501961 rg (https://www.intel.com/content/www/us/en/content-details/315168/intel-trusted-execution-technology-int) Tj T* 0 Tw (el-txt-software-development-guide.html?wapkw=txt) Tj T* ET
+Q
+Q
+ 
+endstream
+endobj
+179 0 obj
+<<
+/Nums [ 0 180 0 R 1 181 0 R 2 182 0 R 3 183 0 R 4 184 0 R 
+  5 185 0 R 6 186 0 R 7 187 0 R 8 188 0 R 9 189 0 R 
+  10 190 0 R 11 191 0 R 12 192 0 R 13 193 0 R ]
+>>
+endobj
+180 0 obj
+<<
+/S /D /St 1
+>>
+endobj
+181 0 obj
+<<
+/S /D /St 2
+>>
+endobj
+182 0 obj
+<<
+/S /D /St 3
+>>
+endobj
+183 0 obj
+<<
+/S /D /St 4
+>>
+endobj
+184 0 obj
+<<
+/S /D /St 5
+>>
+endobj
+185 0 obj
+<<
+/S /D /St 6
+>>
+endobj
+186 0 obj
+<<
+/S /D /St 7
+>>
+endobj
+187 0 obj
+<<
+/S /D /St 8
+>>
+endobj
+188 0 obj
+<<
+/S /D /St 9
+>>
+endobj
+189 0 obj
+<<
+/S /D /St 10
+>>
+endobj
+190 0 obj
+<<
+/S /D /St 11
+>>
+endobj
+191 0 obj
+<<
+/S /D /St 12
+>>
+endobj
+192 0 obj
+<<
+/S /D /St 13
+>>
+endobj
+193 0 obj
+<<
+/S /D /St 14
+>>
+endobj
+xref
+0 194
+0000000000 65535 f 
+0000000073 00000 n 
+0000000175 00000 n 
+0000000282 00000 n 
+0000000394 00000 n 
+0000000601 00000 n 
+0000000769 00000 n 
+0000000937 00000 n 
+0000001105 00000 n 
+0000001273 00000 n 
+0000001441 00000 n 
+0000001610 00000 n 
+0000001779 00000 n 
+0000001948 00000 n 
+0000002117 00000 n 
+0000002286 00000 n 
+0000002455 00000 n 
+0000002624 00000 n 
+0000002794 00000 n 
+0000002964 00000 n 
+0000003134 00000 n 
+0000003304 00000 n 
+0000003474 00000 n 
+0000003644 00000 n 
+0000003814 00000 n 
+0000003984 00000 n 
+0000004154 00000 n 
+0000004324 00000 n 
+0000004494 00000 n 
+0000004664 00000 n 
+0000004834 00000 n 
+0000005004 00000 n 
+0000005174 00000 n 
+0000005344 00000 n 
+0000005514 00000 n 
+0000005684 00000 n 
+0000005854 00000 n 
+0000006024 00000 n 
+0000006194 00000 n 
+0000006364 00000 n 
+0000006534 00000 n 
+0000006704 00000 n 
+0000006874 00000 n 
+0000007044 00000 n 
+0000007214 00000 n 
+0000007384 00000 n 
+0000007554 00000 n 
+0000007724 00000 n 
+0000007894 00000 n 
+0000008064 00000 n 
+0000008234 00000 n 
+0000008404 00000 n 
+0000008574 00000 n 
+0000008744 00000 n 
+0000008914 00000 n 
+0000009084 00000 n 
+0000009254 00000 n 
+0000009424 00000 n 
+0000009594 00000 n 
+0000009764 00000 n 
+0000009934 00000 n 
+0000010104 00000 n 
+0000010274 00000 n 
+0000010444 00000 n 
+0000010614 00000 n 
+0000010784 00000 n 
+0000010954 00000 n 
+0000011124 00000 n 
+0000011294 00000 n 
+0000011464 00000 n 
+0000011634 00000 n 
+0000011804 00000 n 
+0000011974 00000 n 
+0000012144 00000 n 
+0000012314 00000 n 
+0000012484 00000 n 
+0000012654 00000 n 
+0000012824 00000 n 
+0000013564 00000 n 
+0000013734 00000 n 
+0000013904 00000 n 
+0000014074 00000 n 
+0000014244 00000 n 
+0000014414 00000 n 
+0000014584 00000 n 
+0000014754 00000 n 
+0000014924 00000 n 
+0000015094 00000 n 
+0000015264 00000 n 
+0000015434 00000 n 
+0000015604 00000 n 
+0000015774 00000 n 
+0000015944 00000 n 
+0000016114 00000 n 
+0000016284 00000 n 
+0000016454 00000 n 
+0000016624 00000 n 
+0000016816 00000 n 
+0000016932 00000 n 
+0000017288 00000 n 
+0000017408 00000 n 
+0000017617 00000 n 
+0000017724 00000 n 
+0000017933 00000 n 
+0000018142 00000 n 
+0000018254 00000 n 
+0000018369 00000 n 
+0000018578 00000 n 
+0000018787 00000 n 
+0000018996 00000 n 
+0000019205 00000 n 
+0000019414 00000 n 
+0000019623 00000 n 
+0000019832 00000 n 
+0000020135 00000 n 
+0000020438 00000 n 
+0000020675 00000 n 
+0000020785 00000 n 
+0000021071 00000 n 
+0000021149 00000 n 
+0000021351 00000 n 
+0000021603 00000 n 
+0000021860 00000 n 
+0000022052 00000 n 
+0000022379 00000 n 
+0000022722 00000 n 
+0000022951 00000 n 
+0000023258 00000 n 
+0000023565 00000 n 
+0000023827 00000 n 
+0000024020 00000 n 
+0000024339 00000 n 
+0000024658 00000 n 
+0000024912 00000 n 
+0000025169 00000 n 
+0000025441 00000 n 
+0000025706 00000 n 
+0000025995 00000 n 
+0000026224 00000 n 
+0000026503 00000 n 
+0000026731 00000 n 
+0000027044 00000 n 
+0000027313 00000 n 
+0000027681 00000 n 
+0000027945 00000 n 
+0000028222 00000 n 
+0000028556 00000 n 
+0000028848 00000 n 
+0000029196 00000 n 
+0000029509 00000 n 
+0000029822 00000 n 
+0000030089 00000 n 
+0000030338 00000 n 
+0000030691 00000 n 
+0000030925 00000 n 
+0000031248 00000 n 
+0000031447 00000 n 
+0000031736 00000 n 
+0000031954 00000 n 
+0000032223 00000 n 
+0000032477 00000 n 
+0000032860 00000 n 
+0000033113 00000 n 
+0000033366 00000 n 
+0000033649 00000 n 
+0000033816 00000 n 
+0000034627 00000 n 
+0000043228 00000 n 
+0000049991 00000 n 
+0000054633 00000 n 
+0000059351 00000 n 
+0000067325 00000 n 
+0000076272 00000 n 
+0000086793 00000 n 
+0000096377 00000 n 
+0000107641 00000 n 
+0000117941 00000 n 
+0000128141 00000 n 
+0000136150 00000 n 
+0000140305 00000 n 
+0000140488 00000 n 
+0000140523 00000 n 
+0000140558 00000 n 
+0000140593 00000 n 
+0000140628 00000 n 
+0000140663 00000 n 
+0000140698 00000 n 
+0000140733 00000 n 
+0000140768 00000 n 
+0000140803 00000 n 
+0000140839 00000 n 
+0000140875 00000 n 
+0000140911 00000 n 
+0000140947 00000 n 
+trailer
+<<
+/ID 
+[<e466900d250c9c84fe517e14793ffd7c><e466900d250c9c84fe517e14793ffd7c>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 117 0 R
+/Root 116 0 R
+/Size 194
+>>
+startxref
+140983
+%%EOF

--- a/docs/specifications/Secure_Launch.md
+++ b/docs/specifications/Secure_Launch.md
@@ -1,0 +1,8 @@
+Secure Launch Specification
+===========================
+
+The Secure Launch specification describes a common approach for implementing
+Dynamic Launch. This specification is to enable any conforming bootloader to be
+able to initiate a Dynamic Launch of any conforming OS kernel.
+
+<embed src="/assets/secure-launch-specification.pdf" type="application/pdf" width="100%" height="750px"/>

--- a/docs/specifications/index.md
+++ b/docs/specifications/index.md
@@ -1,0 +1,6 @@
+# Specifications
+
+TrenchBoot developed specifications.
+
+{nav}
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,8 @@ nav:
     - Events:
       - events.md
       - upcoming_events.md
+    - Specifications:
+      - ... | specifications/*.md
     - Code:
       - code.md
     - Documentation:


### PR DESCRIPTION
This addes a new specifications section to the site and adds the new Secure Launch Specification as the first specification for publication.