### PR TITLE
mkdocs: fix cname and navbar

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+trenchboot.org

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,24 +10,20 @@ edit_uri: ""
 copyright: Copyright &copy; 2018 - 2021 TrenchBoot Developers 
 
 nav:
-    - Home:
-      - index.md
+    - Home: index.md
     - Events:
       - events.md
       - upcoming_events.md
     - Specifications:
       - ... | specifications/*.md
-    - Code:
-      - code.md
+    - Code: code.md
     - Documentation:
       - ... | documentation/*.md
       - ... | blueprints/*.md
     - Steering Committee:
       - ... | steering-committee/*.md
-    - FAQ:
-      - FAQ.md
-    - Community:
-      - community.md
+    - FAQ: FAQ.md
+    - Community: community.md
 
 use_directory_urls: true
 


### PR DESCRIPTION
This fixes CNAME so that it is included in the generated site. It also adjusts the navbar so that when the hamburger is first clicked, one is not in a submenu.